### PR TITLE
Fix totals budgets

### DIFF
--- a/packages/client/src/pages/Budgets/hooks/useBudgetDataCard.ts
+++ b/packages/client/src/pages/Budgets/hooks/useBudgetDataCard.ts
@@ -8,30 +8,30 @@ interface TotalReturn {
     isPositive: boolean
 }
 
-export const useBudgetDataCard = ({ expenses, incomes }: { expenses: Budget[], incomes: Budget[] }): {
+export const useBudgetDataCard = ({ totalsIncomes, totalsExpenses }: { totalsIncomes: Budget, totalsExpenses: Budget }): {
     expensesTotal: TotalReturn, incomesTotal: TotalReturn, balancePercentage: number,
 } => {
   const expensesTotal = useMemo(() => {
-    const total = expenses?.reduce((sum, { budgets }) => sum + budgets?.[0]?.real, 0) ?? 0
-    const estimated = expenses?.reduce((sum, { budgets }) => sum + budgets?.[0]?.amount, 0) ?? 0
+    const total = totalsExpenses?.budgets?.[0]?.real ?? 0
+    const estimated = totalsExpenses?.budgets?.[0]?.amount ?? 0
     return {
       total,
       estimated,
       percentage: (total / estimated) * 100,
       isPositive: total <= estimated
     }
-  }, [expenses])
+  }, [totalsExpenses])
 
   const incomesTotal = useMemo(() => {
-    const total = incomes?.reduce((sum, { budgets }) => sum + budgets?.[0]?.real, 0) ?? 0
-    const estimated = incomes?.reduce((sum, { budgets }) => sum + budgets?.[0]?.amount, 0) ?? 0
+    const total = totalsIncomes?.budgets?.[0]?.real ?? 0
+    const estimated = totalsIncomes?.budgets?.[0]?.amount ?? 0
     return {
       total,
       estimated,
       percentage: (total / estimated) * 100,
       isPositive: total >= estimated
     }
-  }, [incomes])
+  }, [totalsIncomes])
 
   const balanceTotal = incomesTotal.total - expensesTotal.total
   const balanceEstimated = incomesTotal.estimated - expensesTotal.estimated

--- a/packages/client/src/pages/Budgets/hooks/useBudgets.ts
+++ b/packages/client/src/pages/Budgets/hooks/useBudgets.ts
@@ -4,14 +4,16 @@ import { objectToParams } from 'utils/objectToParams'
 import { Budget } from 'types/budget'
 
 export const useBudgets = (filters: { year?: string, month?: string }): {
-    expenses: Budget[], incomes: Budget[], isLoading: boolean, error: any,
+    expenses: Budget[], incomes: Budget[], isLoading: boolean, error: any, totalsIncomes: Budget, totalsExpenses: Budget
 } => {
   const { data, error } = useSWR(`${BUDGETS}${objectToParams(filters)}`)
 
   return {
     isLoading: !data,
     error,
-    incomes: data?.incomes || [],
-    expenses: data?.expenses || []
+    incomes: data?.incomes?.filter?.(({ id }: Budget) => id !== 'totals') || [],
+    expenses: data?.expenses?.filter?.(({ id }: Budget) => id !== 'totals') || [],
+    totalsIncomes: data?.incomes?.find?.(({ id }: Budget) => id === 'totals') || {},
+    totalsExpenses: data?.expenses?.find?.(({ id }: Budget) => id === 'totals') || {}
   }
 }

--- a/packages/client/src/pages/Budgets/index.tsx
+++ b/packages/client/src/pages/Budgets/index.tsx
@@ -7,8 +7,8 @@ import Header from './components/Header'
 
 const Budgets = () => {
   const { year, month } = useParams()
-  const { expenses, incomes } = useBudgets({ year, month })
-  const { expensesTotal, incomesTotal, balancePercentage } = useBudgetDataCard({ expenses, incomes })
+  const { expenses, incomes, totalsIncomes, totalsExpenses } = useBudgets({ year, month })
+  const { expensesTotal, incomesTotal, balancePercentage } = useBudgetDataCard({ totalsIncomes, totalsExpenses })
 
   return (
         <>


### PR DESCRIPTION
En la página de presupuestos aparecía una categoría llamada Total, que hacía que los datos totales se multiplicaran x2