### PR TITLE
Add payment type from tickets

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/api/src/services/ticket.service.ts
+++ b/packages/api/src/services/ticket.service.ts
@@ -7,6 +7,7 @@ export interface Ticket {
   store: string | null
   amount: number | null
   raw_text: string | null
+  payment_method: string | null
   status: 'pending' | 'reviewed'
   created_at: number
   reviewed_at: number | null

--- a/packages/api/test/routes/ticket.routes.test.ts
+++ b/packages/api/test/routes/ticket.routes.test.ts
@@ -34,7 +34,20 @@ describe('Ticket', () => {
 
     test('when bot responds ok, it should return the tickets with status code 200', async () => {
       const tickets = [
-        { id: faker.string.uuid(), store: faker.company.name(), amount: faker.number.float(), status: 'pending' }
+        {
+          id: faker.string.uuid(),
+          store: faker.company.name(),
+          amount: faker.number.float(),
+          status: 'pending',
+          payment_method: faker.finance.transactionType(),
+          raw_text: null,
+          image_url: null,
+          date: null,
+          telegram_message_id: faker.number.int(),
+          telegram_chat_id: faker.number.int(),
+          created_at: Date.now(),
+          reviewed_at: null
+        }
       ]
       mockFetch(true, { tickets })
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { FormHelperText, Grid } from '@mui/material'
+import { Alert, FormHelperText, Grid } from '@mui/material'
 import { mutate } from 'swr'
 
 import { ModalGrid, DateForm, InputForm, SelectForm, SelectGroupForm } from 'components'
@@ -125,6 +125,22 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         errorText=''
         size={2}
       />
+
+      {ticket.payment_method && (
+        <Grid size={12}>
+          <Alert severity='info' sx={{ py: 0 }}>
+            Método de pago detectado: <strong>{ticket.payment_method}</strong>
+          </Alert>
+        </Grid>
+      )}
+
+      {ticket.raw_text && (
+        <Grid size={12}>
+          <Alert severity='info' icon={false} sx={{ py: 0, fontStyle: 'italic' }}>
+            "{ticket.raw_text}"
+          </Alert>
+        </Grid>
+      )}
 
       {error && (
         <Grid size={12}>

--- a/packages/client/src/pages/Tickets/index.tsx
+++ b/packages/client/src/pages/Tickets/index.tsx
@@ -72,6 +72,19 @@ const Tickets = () => {
                     </Typography>
                   </Stack>
 
+                  {ticket.payment_method && (
+                    <Stack direction='row' justifyContent='space-between'>
+                      <Typography variant='body2' color='text.secondary'>Pago:</Typography>
+                      <Typography variant='body2'>{ticket.payment_method}</Typography>
+                    </Stack>
+                  )}
+
+                  {!ticket.image_url && ticket.raw_text && (
+                    <Typography variant='body2' color='text.secondary' sx={{ fontStyle: 'italic', wordBreak: 'break-word' }}>
+                      "{ticket.raw_text}"
+                    </Typography>
+                  )}
+
                   <Stack direction='row' spacing={1} pt={1}>
                     <Button
                       variant='contained'

--- a/packages/client/src/types/ticket.ts
+++ b/packages/client/src/types/ticket.ts
@@ -7,6 +7,7 @@ export interface Ticket {
   store: string | null
   amount: number | null
   raw_text: string | null
+  payment_method: string | null
   status: 'pending' | 'reviewed'
   created_at: number
   reviewed_at: number | null


### PR DESCRIPTION
## Summary

- Add `payment_method` field to the `Ticket` interface in both API and client packages
- Display payment method and original user message (`raw_text`) on the ticket card
- Show payment method and raw text as informational alerts in the ReviewModal
- Update ticket route tests to include all Ticket fields including `payment_method`

## Changes

### API
- `ticket.service.ts`: add `payment_method: string | null` to `Ticket` interface
- `ticket.routes.test.ts`: update mock ticket to include all fields

### Client
- `src/types/ticket.ts`: add `payment_method: string | null`
- `Tickets/index.tsx`: show "Pago:" row and original message in italics for text-sourced tickets
- `ReviewModal/index.tsx`: informational alerts for payment method and raw text
