### PR TITLE
fix: refresh transaction list after add or delete

### DIFF
--- a/packages/client/src/pages/Transactions/components/TransactionEdit/index.tsx
+++ b/packages/client/src/pages/Transactions/components/TransactionEdit/index.tsx
@@ -48,7 +48,7 @@ const TransactionEdit = ({
       error
     } = transaction?._id ? await editTransaction(transaction._id, formattedParams as any) : await addTransaction(formattedParams as any)
     if (!error) {
-      await mutate(query)
+      await mutate((key) => typeof key === 'string' && key.startsWith(TRANSACTIONS))
       hideForm()
     }
     setError(error)
@@ -57,10 +57,7 @@ const TransactionEdit = ({
   const handleDeleteButton = async () => {
     if (!isNew && transaction?._id) {
       await deleteTransaction(transaction._id)
-      // @ts-ignore
-      await mutate(TRANSACTIONS, async (transactions: Transaction[]) => {
-        return transactions.filter(t => t._id !== transaction?._id)
-      })
+      await mutate((key) => typeof key === 'string' && key.startsWith(TRANSACTIONS))
     }
 
     hideForm()


### PR DESCRIPTION
## Summary

- Al añadir una transacción, `mutate(query)` recibía `query=''` (string vacío) porque el formulario de nueva transacción no tenía una clave SWR válida, por lo que la caché nunca se invalidaba y la lista no se actualizaba.
- Al eliminar una transacción, `mutate(TRANSACTIONS, ...)` usaba la clave base `'transactions'` en lugar de las claves paginadas reales (`'transactions?page=0&...'`), por lo que la actualización optimista nunca se aplicaba.

## Solución

Se reemplaza ambos `mutate` por una llamada con función de filtro que invalida todas las claves de SWR que comiencen por `TRANSACTIONS`, siguiendo el patrón recomendado por SWR v2 para invalidar múltiples entradas de caché relacionadas.

Closes #63