### PR TITLE
fix: resolve Docker build failures for api image

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -12,10 +12,12 @@ ENV TZ=Europe/Madrid
 COPY --chown=node:node pnpm-workspace.yaml pnpm-lock.yaml package.json .npmrc ./
 
 COPY --chown=node:node packages/api/package.json ./packages/api/
+COPY --chown=node:node packages/models/package.json ./packages/models/
 
 RUN pnpm install --frozen-lockfile --filter @soker90/finper-api...
 
 COPY --chown=node:node packages/api ./packages/api
+COPY --chown=node:node packages/models ./packages/models
 RUN pnpm --filter @soker90/finper-api build
 
 # STAGE 2 - Producción

--- a/packages/api/src/services/utils/calcLoanProjection.ts
+++ b/packages/api/src/services/utils/calcLoanProjection.ts
@@ -218,7 +218,17 @@ export const buildAmortizationTable = (
   let accum = real[real.length - 1]?.accumulatedPrincipal ?? 0
   const projected: AmortizationRow[] = projectedRaw.map(p => {
     accum = roundNumber(accum + p.principal)
-    return { ...p, accumulatedPrincipal: accum, isProjected: true }
+    return {
+      period: p.period,
+      date: p.date,
+      amount: p.amount,
+      interest: p.interest,
+      principal: p.principal,
+      accumulatedPrincipal: accum,
+      pendingCapital: p.pendingCapital,
+      type: p.type,
+      isProjected: true
+    }
   })
 
   return [...real, ...projected]


### PR DESCRIPTION
## Summary

- Add `packages/models` to the Dockerfile builder stage so pnpm can resolve the `workspace:*` dependency on `@soker90/finper-models` during `pnpm install --frozen-lockfile`
- Fix `TS2322` in `calcLoanProjection.ts` by mapping `projectedRaw` to `AmortizationRow` explicitly instead of spreading `ProjectedPayment` (which lacks `isProjected` in its type definition)

## Root cause

The Docker build was copying only `packages/api` but not `packages/models`, so the workspace dependency could not be resolved inside the container. The TypeScript error was a side effect of the spread operator producing a type incompatible with `AmortizationRow[]`.