### PR TITLE
ci: cache mongodb-binaries to prevent transient download failures

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,6 +68,10 @@ jobs:
         with:
           cache: 'pnpm'
           node-version-file: '.nvmrc'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test
@@ -131,6 +135,10 @@ jobs:
         with:
           cache: 'pnpm'
           node-version-file: '.nvmrc'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}
       - uses: actions/download-artifact@v8
         with:
           name: models


### PR DESCRIPTION
## Summary

- Add `actions/cache` for `~/.cache/mongodb-binaries` in both `test-models` and `test-api` jobs

## Root cause

`mongodb-memory-server` downloads the MongoDB binary on first run. Without a cache, each CI run re-downloads it and multiple Jest workers race to spawn it simultaneously, causing `ENOENT` (download incomplete) and `spawn ETXTBSY` (binary busy being written) errors. With the cache the binary is restored before tests run, eliminating the race condition.