### PR TITLE
fix(loans): restrict loan edit to name, account and category

### DIFF
--- a/packages/api/src/validators/loan/validate-loan-edit-params.ts
+++ b/packages/api/src/validators/loan/validate-loan-edit-params.ts
@@ -12,9 +12,6 @@ export const validateLoanEditParams = async ({
 
   const schema = Joi.object({
     name: Joi.string(),
-    interestRate: Joi.number().min(0),
-    startDate: Joi.number(),
-    monthlyPayment: Joi.number().positive(),
     account: Joi.string(),
     category: Joi.string()
   })

--- a/packages/api/test/routes/loan.routes.test.ts
+++ b/packages/api/test/routes/loan.routes.test.ts
@@ -170,9 +170,15 @@ describe('Loans', () => {
     const path = (id: string) => `/api/loans/${id}`
     let token: string
     const user = generateUsername()
+    let accountId: string
+    let categoryId: string
 
     beforeAll(async () => {
       token = await requestLogin(server.app, { username: user })
+      const account = await insertAccount({ user })
+      accountId = account._id.toString()
+      const category = await insertCategory({ user })
+      categoryId = category._id.toString()
     })
 
     test('when token is not provided, it should respond 401', async () => {
@@ -196,16 +202,30 @@ describe('Loans', () => {
         .expect(404)
     })
 
-    test('when success, it should respond 200', async () => {
+    test.each(['initialAmount', 'interestRate', 'monthlyPayment', 'startDate'])(
+      'when body contains only %s (financial field), it should respond 422',
+      async (field) => {
+        const loan = await insertLoan({ user })
+        await supertest(server.app)
+          .put(path(loan._id.toString()))
+          .auth(token, { type: 'bearer' })
+          .send({ [field]: 9999 })
+          .expect(422)
+      }
+    )
+
+    test('when success, it should respond 200 and update name, account and category', async () => {
       const loan = await insertLoan({ user })
       const newName = faker.lorem.words(2)
       const res = await supertest(server.app)
         .put(path(loan._id.toString()))
         .auth(token, { type: 'bearer' })
-        .send({ name: newName })
+        .send({ name: newName, account: accountId, category: categoryId })
         .expect(200)
 
       expect(res.body.name).toBe(newName)
+      expect(res.body.account).toBe(accountId)
+      expect(res.body.category).toBe(categoryId)
     })
   })
 

--- a/packages/client/src/pages/Loans/components/LoanFormModal/index.tsx
+++ b/packages/client/src/pages/Loans/components/LoanFormModal/index.tsx
@@ -52,21 +52,24 @@ const LoanFormModal = ({ loan, onClose }: Props) => {
   }, [reset, loan, accounts, categories])
 
   const onSubmit = handleSubmit(async (params) => {
-    const body = {
+    const commonBody = {
       name: params.name,
-      initialAmount: Number(params.initialAmount),
-      interestRate: Number(params.interestRate),
-      monthlyPayment: Number(params.monthlyPayment),
-      startDate: params.startDate ? new Date(params.startDate).getTime() : undefined,
       account: params.account,
       category: params.category
     }
 
     if (isEdit) {
-      const { error } = await editLoan(loan!._id!, body)
+      const { error } = await editLoan(loan!._id!, commonBody)
       if (error) { setApiError(error); return }
       await mutate(LOAN_DETAIL(loan!._id!))
     } else {
+      const body = {
+        ...commonBody,
+        initialAmount: Number(params.initialAmount),
+        interestRate: Number(params.interestRate),
+        monthlyPayment: Number(params.monthlyPayment),
+        startDate: params.startDate ? new Date(params.startDate).getTime() : undefined
+      }
       const { error } = await addLoan(body)
       if (error) { setApiError(error); return }
     }
@@ -81,30 +84,34 @@ const LoanFormModal = ({ loan, onClose }: Props) => {
         error={!!errors.name} errorText='Nombre requerido'
         {...register('name', { required: true })}
       />
-      <InputForm
-        id='initialAmount' label='Capital inicial' type='number'
-        inputProps={{ step: 'any', min: 0 }}
-        error={!!errors.initialAmount} errorText='Capital inicial requerido'
-        {...register('initialAmount', { required: true, valueAsNumber: true })}
-      />
-      <InputForm
-        id='interestRate' label='TIN anual (%)' type='number'
-        inputProps={{ step: 'any', min: 0 }}
-        error={!!errors.interestRate} errorText='TIN requerido'
-        {...register('interestRate', { required: true, valueAsNumber: true })}
-      />
-      <InputForm
-        id='monthlyPayment' label='Cuota mensual' type='number'
-        inputProps={{ step: 'any', min: 0 }}
-        error={!!errors.monthlyPayment} errorText='Cuota mensual requerida'
-        {...register('monthlyPayment', { required: true, valueAsNumber: true })}
-      />
-      <DateForm
-        id='startDate' label='Fecha primer pago'
-        placeholder='Fecha primer pago'
-        error={!!errors.startDate}
-        control={control}
-      />
+      {!isEdit && (
+        <>
+          <InputForm
+            id='initialAmount' label='Capital inicial' type='number'
+            inputProps={{ step: 'any', min: 0 }}
+            error={!!errors.initialAmount} errorText='Capital inicial requerido'
+            {...register('initialAmount', { required: true, valueAsNumber: true })}
+          />
+          <InputForm
+            id='interestRate' label='TIN anual (%)' type='number'
+            inputProps={{ step: 'any', min: 0 }}
+            error={!!errors.interestRate} errorText='TIN requerido'
+            {...register('interestRate', { required: true, valueAsNumber: true })}
+          />
+          <InputForm
+            id='monthlyPayment' label='Cuota mensual' type='number'
+            inputProps={{ step: 'any', min: 0 }}
+            error={!!errors.monthlyPayment} errorText='Cuota mensual requerida'
+            {...register('monthlyPayment', { required: true, valueAsNumber: true })}
+          />
+          <DateForm
+            id='startDate' label='Fecha primer pago'
+            placeholder='Fecha primer pago'
+            error={!!errors.startDate}
+            control={control}
+          />
+        </>
+      )}
       <SelectForm
         id='account' label='Cuenta vinculada'
         options={accounts}


### PR DESCRIPTION
Closes #609

## Changes

### Backend
- Reduced Joi schema in `validate-loan-edit-params.ts` to only accept `name`, `account` and `category`
- Financial fields (`initialAmount`, `interestRate`, `monthlyPayment`, `startDate`) are no longer accepted and return 422

### Frontend
- `LoanFormModal` now shows only `name`, `account` and `category` fields when in edit mode
- All fields remain visible when creating a new loan
- The `onSubmit` handler only sends the allowed fields when editing

### Tests
- Updated `PUT /api/loans/:id` tests to verify financial fields are rejected (422)
- Consolidated success test to send all three allowed fields together