### PR TITLE
fix: replace deprecated mongoose 'new' option with 'returnDocument: after'

### DIFF
--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -20,7 +20,7 @@ export default class AccountService implements IAccountService {
   }
 
   public async editAccount ({ id, value }: { id: string, value: IAccount }): Promise<AccountDocument> {
-    const updated = await AccountModel.findByIdAndUpdate<AccountDocument>(id, value, { new: true })
+    const updated = await AccountModel.findByIdAndUpdate<AccountDocument>(id, value, { returnDocument: 'after' })
     if (!updated) throw Boom.notFound(ERROR_MESSAGE.ACCOUNT.NOT_FOUND).output
     return updated
   }

--- a/packages/api/src/services/budget.service.ts
+++ b/packages/api/src/services/budget.service.ts
@@ -168,7 +168,7 @@ export default class BudgetService implements IBudgetService {
 
   async editBudget ({ category, year, month, user, amount }: IBudget): Promise<IBudget> {
     return await BudgetModel.findOneAndUpdate({ category, year, month, user }, { amount }, {
-      new: true,
+      returnDocument: 'after',
       upsert: true
     }) as unknown as IBudget
   }

--- a/packages/api/src/services/category.service.ts
+++ b/packages/api/src/services/category.service.ts
@@ -54,7 +54,7 @@ export default class CategoryService implements ICategoryService {
   }
 
   public async editCategory ({ id, value }: { id: string, value: ICategory }): Promise<CategoryDocument> {
-    const updated = await CategoryModel.findByIdAndUpdate<CategoryDocument>(id, value, { new: true })
+    const updated = await CategoryModel.findByIdAndUpdate<CategoryDocument>(id, value, { returnDocument: 'after' })
     if (!updated) throw Boom.notFound(ERROR_MESSAGE.CATEGORY.NOT_FOUND).output
     return updated
   }

--- a/packages/api/src/services/debt.service.ts
+++ b/packages/api/src/services/debt.service.ts
@@ -21,7 +21,7 @@ export default class DebtService implements IDebtService {
   }
 
   public async editDebt ({ id, value }: { id: string, value: IDebt }): Promise<DebtDocument> {
-    const updated = await DebtModel.findByIdAndUpdate<DebtDocument>(id, value, { new: true })
+    const updated = await DebtModel.findByIdAndUpdate<DebtDocument>(id, value, { returnDocument: 'after' })
     if (!updated) throw Boom.notFound(ERROR_MESSAGE.DEBT.NOT_FOUND).output
     return updated
   }

--- a/packages/api/src/services/loan.service.ts
+++ b/packages/api/src/services/loan.service.ts
@@ -106,7 +106,7 @@ export default class LoanService implements ILoanService {
   }
 
   async editLoan (id: string, data: Partial<ILoan>): Promise<ILoan & { _id: string }> {
-    const updated = await leanDoc<ILoan & { _id: string } | null>(LoanModel.findByIdAndUpdate(id, data, { new: true }).lean())
+    const updated = await leanDoc<ILoan & { _id: string } | null>(LoanModel.findByIdAndUpdate(id, data, { returnDocument: 'after' }).lean())
     if (!updated) throw Boom.notFound(ERROR_MESSAGE.LOAN.NOT_FOUND).output
     return updated
   }

--- a/packages/api/src/services/pension.service.ts
+++ b/packages/api/src/services/pension.service.ts
@@ -64,6 +64,6 @@ export default class PensionService implements IPensionService {
   }
 
   public async editPension ({ id, value }: { id: string, value: IPension }): Promise<IPension> {
-    return await PensionModel.findByIdAndUpdate(id, value, { new: true }) as unknown as IPension
+    return await PensionModel.findByIdAndUpdate(id, value, { returnDocument: 'after' }) as unknown as IPension
   }
 }

--- a/packages/api/src/services/stores.service.ts
+++ b/packages/api/src/services/stores.service.ts
@@ -16,7 +16,7 @@ export default class StoreService implements IStoreService {
         name: storeName,
         user: transaction.user
       }, { name: storeName, user: transaction.user }, {
-        new: true,
+        returnDocument: 'after',
         upsert: true
       }) as StoreDocument
       transaction.store = store._id

--- a/packages/api/src/services/subscription.service.ts
+++ b/packages/api/src/services/subscription.service.ts
@@ -59,7 +59,7 @@ export default class SubscriptionService implements ISubscriptionService {
   }
 
   async editSubscription (id: string, value: Partial<ISubscription>): Promise<SubscriptionDocument | null> {
-    return SubscriptionModel.findByIdAndUpdate(id, value, { new: true })
+    return SubscriptionModel.findByIdAndUpdate(id, value, { returnDocument: 'after' })
   }
 
   async deleteSubscription (id: string): Promise<void> {

--- a/packages/api/src/services/transaction.service.ts
+++ b/packages/api/src/services/transaction.service.ts
@@ -56,7 +56,7 @@ export default class TransactionService implements ITransactionService {
     if (!oldTransaction) throw Boom.notFound(ERROR_MESSAGE.TRANSACTION.NOT_FOUND).output
     const oldAmount = getTransactionAmount(oldTransaction)
 
-    const transaction = await TransactionModel.findByIdAndUpdate<TransactionDocument>(id, value, { new: true })
+    const transaction = await TransactionModel.findByIdAndUpdate<TransactionDocument>(id, value, { returnDocument: 'after' })
     if (!transaction) throw Boom.notFound(ERROR_MESSAGE.TRANSACTION.NOT_FOUND).output
     const newAmount = getTransactionAmount(transaction)
 


### PR DESCRIPTION
Fixes Mongoose 8+ deprecation warning across all services.

## Changes
Replaced the deprecated `new: true` option in `findOneAndUpdate` / `findByIdAndUpdate` calls with `returnDocument: 'after'` in 9 service files:

- `account.service.ts`
- `budget.service.ts`
- `category.service.ts`
- `debt.service.ts`
- `loan.service.ts`
- `pension.service.ts`
- `stores.service.ts`
- `subscription.service.ts`
- `transaction.service.ts`

No logic changes — behaviour is identical.