### PR TITLE
Supply/models

### DIFF
--- a/.agents/skills/pnpm-makefile/SKILL.md
+++ b/.agents/skills/pnpm-makefile/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: Use PNPM and Makefile
+description: Rule to enforce using PNPM and the Makefile for all build, start, and lint processes, rather than npm. Use this skill whenever working within the workspace, running scripts or managing dependencies.
+---
+
+# Use PNPM and Makefile
+
+Este proyecto es un monorepo que utiliza **`pnpm`** como gestor de paquetes. **NUNCA** debes utilizar `npm` o `yarn` para instalar dependencias o ejecutar scripts, ya que esto podría causar problemas con el `pnpm-lock.yaml` o los contextos del espacio de trabajo (workspace).
+
+## Reglas Principales:
+
+1. **Usa `pnpm` en lugar de `npm`:**
+   - Para instalar: `pnpm install`
+   - Para añadir al workspace: `pnpm add <pkg> --filter @soker90/finper-<paquete>`
+   
+2. **Usa el `Makefile` de la raíz:**
+   El proyecto dispone de un `Makefile` en la raíz con comandos predefinidos para interactuar con los diferentes paquetes. **Utiliza comandos de `make` siempre que sea posible.**
+   
+   Comandos principales disponibles:
+   - `make install` -> Instala todas las dependencias
+   - `make build-models` -> Construye el paquete de modelos
+   - `make build-api` -> Construye el paquete del api
+   - `make test-models` -> Ejecuta los tests de los modelos
+   - `make test-api` -> Ejecuta los tests del api
+   - `make start-api` -> Arranca el servidor local
+   
+   *Nota: Revisa el Makefile de la raíz si necesitas un comando específico, como el de linting o despliegue en local.*
+
+3. **Restricción de Versión de Node:**
+   Si a pesar de todo `pnpm` falla por la versión del motor de Node.js, confía en el fichero `.npmrc` (donde `engine-strict=false`) para bypass del chequeo temporalmente mientras ejecutas tus comandos en el shell.

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ shamefully-hoist=false
 strict-peer-dependencies=false
 auto-install-peers=true
 inject-workspace-packages=true
+engine-strict=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+### Rules for AI assistants and contributors
+
+- **Use pnpm instead of npm**
+- **Never use `^` or `~`** in dependency version specifiers. Always pin exact versions.
+- **Always commit the lockfile** (`pnpm-lock.yaml`). Never delete it or add it to `.gitignore`.
+- **Install scripts are disabled**. If a new dependency requires a build step, it must be explicitly approved.
+- **New package versions must be at least 1 day old** before they can be installed (release age gating is enabled).
+- When adding a dependency, verify it on [npmjs.com](https://www.npmjs.com) before installing.
+- Prefer well-maintained packages with verified publishers and provenance.
+- Run `pnpm install` with the lockfile present — never bypass it.
+- Do not add git-based or tarball URL dependencies unless explicitly approved.
+- **Do not run `npm update`**, `npx npm-check-updates`, or any blind upgrade command. Review each update individually.
+- **Use deterministic installs**: prefer `pnpm install --frozen-lockfile` over `pnpm install` in CI and scripts.

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -17,6 +17,9 @@ import { ILoanPayment, LoanPaymentModel, LoanPaymentType, LOAN_PAYMENT } from '.
 import { ILoanEvent, LoanEventModel } from './models/loan-events'
 import { ISubscription, SubscriptionModel } from './models/subscriptions'
 import { ISubscriptionCandidate, SubscriptionCandidateModel } from './models/subscription-candidates'
+import { IProperty, PropertyModel } from './models/properties'
+import { ISupply, SupplyModel, SUPPLY_TYPE, SupplyType } from './models/supplies'
+import { ISupplyReading, SupplyReadingModel } from './models/supply-readings'
 
 export type { AccountDocument } from './models/accounts'
 export type { BudgetDocument } from './models/budgets'
@@ -31,6 +34,9 @@ export type { TransactionDocument } from './models/transactions'
 export type { UserDocument } from './models/users'
 export type { SubscriptionDocument } from './models/subscriptions'
 export type { SubscriptionCandidateDocument } from './models/subscription-candidates'
+export type { PropertyDocument } from './models/properties'
+export type { SupplyDocument } from './models/supplies'
+export type { SupplyReadingDocument } from './models/supply-readings'
 
 function connect (uri: string, options: Record<string, unknown>): void {
   if (isNil(mongoose)) {
@@ -60,6 +66,8 @@ export {
   LoanPaymentType,
   TRANSACTION,
   TransactionType,
+  SUPPLY_TYPE,
+  SupplyType,
 
   IAccount,
   IBudget,
@@ -74,6 +82,9 @@ export {
   ISubscriptionCandidate,
   ITransaction,
   IUser,
+  IProperty,
+  ISupply,
+  ISupplyReading,
 
   AccountModel,
   BudgetModel,
@@ -87,5 +98,8 @@ export {
   SubscriptionModel,
   SubscriptionCandidateModel,
   TransactionModel,
-  UserModel
+  UserModel,
+  PropertyModel,
+  SupplyModel,
+  SupplyReadingModel
 }

--- a/packages/models/src/models/properties.ts
+++ b/packages/models/src/models/properties.ts
@@ -1,0 +1,15 @@
+import { Schema, model, HydratedDocument } from 'mongoose'
+
+export interface IProperty {
+  name: string
+  user: string
+}
+
+export type PropertyDocument = HydratedDocument<IProperty>
+
+const propertySchema = new Schema<IProperty>({
+  name: { type: String, required: true },
+  user: { type: String, required: true }
+}, { versionKey: false })
+
+export const PropertyModel = model<IProperty>('Property', propertySchema)

--- a/packages/models/src/models/supplies.ts
+++ b/packages/models/src/models/supplies.ts
@@ -1,0 +1,27 @@
+import { Schema, model, HydratedDocument, Types } from 'mongoose'
+
+export const SUPPLY_TYPE = {
+  ELECTRICITY: 'electricity',
+  WATER: 'water',
+  GAS: 'gas'
+} as const
+
+export type SupplyType = typeof SUPPLY_TYPE[keyof typeof SUPPLY_TYPE]
+
+export interface ISupply {
+  name: string
+  type: SupplyType
+  propertyId: Types.ObjectId
+  user: string
+}
+
+export type SupplyDocument = HydratedDocument<ISupply>
+
+const supplySchema = new Schema<ISupply>({
+  name: { type: String, required: true },
+  type: { type: String, enum: Object.values(SUPPLY_TYPE), required: true },
+  propertyId: { type: Schema.Types.ObjectId, required: true, ref: 'Property' },
+  user: { type: String, required: true }
+}, { versionKey: false })
+
+export const SupplyModel = model<ISupply>('Supply', supplySchema)

--- a/packages/models/src/models/supply-readings.ts
+++ b/packages/models/src/models/supply-readings.ts
@@ -1,0 +1,27 @@
+import { Schema, model, HydratedDocument, Types } from 'mongoose'
+
+export interface ISupplyReading {
+  supplyId: Types.ObjectId
+  startDate: number
+  endDate: number
+  consumption?: number
+  consumptionPeak?: number
+  consumptionFlat?: number
+  consumptionOffPeak?: number
+  user: string
+}
+
+export type SupplyReadingDocument = HydratedDocument<ISupplyReading>
+
+const supplyReadingSchema = new Schema<ISupplyReading>({
+  supplyId: { type: Schema.Types.ObjectId, required: true, ref: 'Supply' },
+  startDate: { type: Number, required: true },
+  endDate: { type: Number, required: true },
+  consumption: { type: Number },
+  consumptionPeak: { type: Number },
+  consumptionFlat: { type: Number },
+  consumptionOffPeak: { type: Number },
+  user: { type: String, required: true }
+}, { versionKey: false })
+
+export const SupplyReadingModel = model<ISupplyReading>('SupplyReading', supplyReadingSchema)

--- a/packages/models/test/helpers/create-property.ts
+++ b/packages/models/test/helpers/create-property.ts
@@ -1,0 +1,12 @@
+import { faker } from '@faker-js/faker'
+import { HydratedDocument } from 'mongoose'
+
+import { PropertyModel, IProperty } from '../../src'
+
+export default (params = {}): Promise<HydratedDocument<IProperty>> => (
+  PropertyModel.create({
+    name: faker.company.name(),
+    user: faker.internet.username(),
+    ...params
+  })
+)

--- a/packages/models/test/helpers/create-supply-reading.ts
+++ b/packages/models/test/helpers/create-supply-reading.ts
@@ -1,0 +1,18 @@
+import { faker } from '@faker-js/faker'
+import { HydratedDocument } from 'mongoose'
+
+import { SupplyReadingModel, ISupplyReading } from '../../src'
+import createSupply from './create-supply'
+
+export default async (params: any = {}): Promise<HydratedDocument<ISupplyReading>> => {
+  const supplyId = params.supplyId || (await createSupply())._id
+
+  return SupplyReadingModel.create({
+    supplyId,
+    startDate: faker.date.recent().getTime(),
+    endDate: faker.date.recent().getTime(),
+    consumption: faker.number.int({ min: 10, max: 100 }),
+    user: faker.internet.username(),
+    ...params
+  })
+}

--- a/packages/models/test/helpers/create-supply.ts
+++ b/packages/models/test/helpers/create-supply.ts
@@ -1,0 +1,17 @@
+import { faker } from '@faker-js/faker'
+import { HydratedDocument } from 'mongoose'
+
+import { SupplyModel, ISupply, SUPPLY_TYPE } from '../../src'
+import createProperty from './create-property'
+
+export default async (params: any = {}): Promise<HydratedDocument<ISupply>> => {
+  const propertyId = params.propertyId || (await createProperty())._id
+
+  return SupplyModel.create({
+    name: faker.company.name(),
+    type: faker.helpers.objectValue(SUPPLY_TYPE),
+    propertyId,
+    user: faker.internet.username(),
+    ...params
+  })
+}

--- a/packages/models/test/models/properties.test.ts
+++ b/packages/models/test/models/properties.test.ts
@@ -1,0 +1,57 @@
+import { PropertyModel, PropertyDocument, mongoose } from '../../src'
+import createProperty from '../helpers/create-property'
+
+const testDatabase = require('../test-db')(mongoose)
+
+const testProperty = (expected: PropertyDocument, received: PropertyDocument) => {
+  expect(expected.name).toBe(received.name)
+  expect(expected.user).toBe(received.user)
+}
+
+describe('Property', () => {
+  beforeAll(() => testDatabase.connect())
+
+  afterAll(() => testDatabase.close())
+
+  describe('when there is a new property', () => {
+    let propertyData: PropertyDocument
+
+    beforeAll(() => createProperty().then((property) => {
+      propertyData = property
+    }))
+
+    afterAll(() => testDatabase.clear())
+
+    test('it should contain all the defined properties', async () => {
+      const propertyDocument: PropertyDocument = await PropertyModel.findOne()
+
+      testProperty(propertyDocument, propertyData)
+    })
+  })
+
+  describe('when there are multiple properties', () => {
+    let firstProperty: PropertyDocument
+
+    beforeAll(async () => {
+      firstProperty = await createProperty()
+
+      await Promise.all([
+        createProperty(),
+        createProperty()
+      ])
+    })
+
+    afterAll(() => testDatabase.clear())
+
+    test('it should be 3 properties stored', async () => {
+      const propertyCounter = await PropertyModel.countDocuments()
+      expect(propertyCounter).toBe(3)
+    })
+
+    test('it should contain all the defined properties of the first property', async () => {
+      const propertyDocument: PropertyDocument = await PropertyModel.findOne({ _id: firstProperty._id })
+
+      testProperty(propertyDocument, firstProperty)
+    })
+  })
+})

--- a/packages/models/test/models/supplies.test.ts
+++ b/packages/models/test/models/supplies.test.ts
@@ -1,0 +1,33 @@
+import { SupplyModel, SupplyDocument, mongoose } from '../../src'
+import createSupply from '../helpers/create-supply'
+
+const testDatabase = require('../test-db')(mongoose)
+
+const testSupply = (expected: SupplyDocument, received: SupplyDocument) => {
+  expect(expected.name).toBe(received.name)
+  expect(expected.type).toBe(received.type)
+  expect(expected.user).toBe(received.user)
+  expect(expected.propertyId.toString()).toBe(received.propertyId.toString())
+}
+
+describe('Supply', () => {
+  beforeAll(() => testDatabase.connect())
+
+  afterAll(() => testDatabase.close())
+
+  describe('when there is a new supply', () => {
+    let supplyData: SupplyDocument
+
+    beforeAll(() => createSupply().then((supply) => {
+      supplyData = supply
+    }))
+
+    afterAll(() => testDatabase.clear())
+
+    test('it should contain all the defined properties', async () => {
+      const supplyDocument: SupplyDocument = await SupplyModel.findOne()
+
+      testSupply(supplyDocument, supplyData)
+    })
+  })
+})

--- a/packages/models/test/models/supply-readings.test.ts
+++ b/packages/models/test/models/supply-readings.test.ts
@@ -1,0 +1,34 @@
+import { SupplyReadingModel, SupplyReadingDocument, mongoose } from '../../src'
+import createSupplyReading from '../helpers/create-supply-reading'
+
+const testDatabase = require('../test-db')(mongoose)
+
+const testSupplyReading = (expected: SupplyReadingDocument, received: SupplyReadingDocument) => {
+  expect(expected.supplyId.toString()).toBe(received.supplyId.toString())
+  expect(expected.startDate).toBe(received.startDate)
+  expect(expected.endDate).toBe(received.endDate)
+  expect(expected.user).toBe(received.user)
+}
+
+describe('SupplyReading', () => {
+  beforeAll(() => testDatabase.connect())
+
+  afterAll(() => testDatabase.close())
+
+  describe('when there is a new supply reading', () => {
+    let readingData: SupplyReadingDocument
+
+    beforeAll(() => createSupplyReading().then((reading) => {
+      readingData = reading
+    }))
+
+    afterAll(() => testDatabase.clear())
+
+    test('it should contain all the defined properties', async () => {
+      // @ts-ignore - mongoose typing mismatch
+      const readingDocument: SupplyReadingDocument = await SupplyReadingModel.findOne()
+
+      testSupplyReading(readingDocument, readingData)
+    })
+  })
+})


### PR DESCRIPTION
This pull request introduces new models for properties, supplies, and supply readings to the `packages/models` package, along with their associated tests and helper functions. It also updates the main model index to export these new entities. Additionally, there are new documentation files and stricter rules for dependency management and workspace scripts.

**New Models and Exports**

* Added `PropertyModel`, `SupplyModel`, and `SupplyReadingModel` Mongoose schemas, including their TypeScript interfaces and types (`IProperty`, `ISupply`, `ISupplyReading`, etc.) to support property and utility supply tracking. [[1]](diffhunk://#diff-667f6232ce9c81655cef27f883dd233e411cf198d9ac2e41f3e2088fbb7a1af2R1-R15) [[2]](diffhunk://#diff-c08f521c217eb135a2dcdec57aeb2101956ce6f871fa686aa9cb7d8097e5dc2eR1-R27) [[3]](diffhunk://#diff-03bdda258033e0aa1606fcad49ec4e0e23c94c5447bb0b31811e7abc11b8f19fR1-R27)
* Updated `packages/models/src/index.ts` to export the new models, types, and enums for use throughout the workspace. [[1]](diffhunk://#diff-7794d0c612323dc86c27b6bd9058d68c031894b178b93ec2dd4b88ee57bae541R20-R22) [[2]](diffhunk://#diff-7794d0c612323dc86c27b6bd9058d68c031894b178b93ec2dd4b88ee57bae541R37-R39) [[3]](diffhunk://#diff-7794d0c612323dc86c27b6bd9058d68c031894b178b93ec2dd4b88ee57bae541R69-R70) [[4]](diffhunk://#diff-7794d0c612323dc86c27b6bd9058d68c031894b178b93ec2dd4b88ee57bae541R85-R87) [[5]](diffhunk://#diff-7794d0c612323dc86c27b6bd9058d68c031894b178b93ec2dd4b88ee57bae541L90-R104)

**Testing Infrastructure**

* Added unit tests for the new models: `properties.test.ts`, `supplies.test.ts`, and `supply-readings.test.ts`, ensuring correct creation and retrieval of documents. [[1]](diffhunk://#diff-2aff41de06e1932614f7c1751a8b5810e3028e95e07a6fc2c64ea279044b49eaR1-R57) [[2]](diffhunk://#diff-908491aafdf6c5c6edf9d6c3a32e771453cd331559ac142b4e1222747a6c6e0aR1-R33) [[3]](diffhunk://#diff-861bbef4b30eb9ae5e4aeb15579d17f0c474901c3046c7ed11fb8c53a48f5298R1-R34)
* Created helper functions for generating test data for properties, supplies, and supply readings using `faker`. [[1]](diffhunk://#diff-a24cf00a905133a2e2245e639cca13c68d39aae10d7acd82be8385b659367167R1-R12) [[2]](diffhunk://#diff-433a2e81aae68e9ee230d510a6d96089bfa623bf42c63d73951133b417f50f3fR1-R17) [[3]](diffhunk://#diff-eff00753c5dbf54d134fc98b2cc1e5775aa1b20b639c20898ce57f44668ea02eR1-R18)

**Workspace and Dependency Management Rules**

* Added `.agents/skills/pnpm-makefile/SKILL.md` and `AGENTS.md` to document and enforce the use of `pnpm` and the workspace `Makefile` for all scripts and dependency management, including rules for deterministic installs and dependency vetting. [[1]](diffhunk://#diff-428cea40e8215a557ba797b7cea63e6353b94b26c3f397f25e197257b6cb921dR1-R30) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R15)
* Updated `.npmrc` to set `engine-strict=false`, allowing temporary bypass of Node.js engine checks.