### PR TITLE
Ordenar lecturas: últimas primero

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/api/src/services/supply-reading.service.ts
+++ b/packages/api/src/services/supply-reading.service.ts
@@ -11,7 +11,7 @@ export interface ISupplyReadingService {
 
 export default class SupplyReadingService implements ISupplyReadingService {
   public async getSupplyReadings ({ supplyId, user }: { supplyId: string, user: string }): Promise<SupplyReadingDocument[]> {
-    return SupplyReadingModel.find({ supplyId, user }).sort({ startDate: 1 })
+    return SupplyReadingModel.find({ supplyId, user }).sort({ startDate: -1, endDate: -1 })
   }
 
   public async addReading (reading: ISupplyReading): Promise<SupplyReadingDocument> {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/mock/handlers/supplies.ts
+++ b/packages/client/src/mock/handlers/supplies.ts
@@ -46,7 +46,10 @@ export const suppliesHandlers = [
 
   // Readings — rutas estáticas ANTES de /supplies/:id
   http.get('/supplies/readings/supply/:supplyId', ({ params }) => {
-    return HttpResponse.json(READINGS_LIST.filter(r => r.supplyId === params.supplyId))
+    const filtered = READINGS_LIST
+      .filter(r => r.supplyId === params.supplyId)
+      .toSorted((a, b) => b.startDate - a.startDate || b.endDate - a.endDate)
+    return HttpResponse.json(filtered)
   }),
   http.post('/supplies/readings', async ({ request }) => {
     const body = await request.json() as Record<string, any>

--- a/packages/client/src/pages/SupplyDetail/SupplyDetail.test.tsx
+++ b/packages/client/src/pages/SupplyDetail/SupplyDetail.test.tsx
@@ -55,7 +55,8 @@ describe('SupplyDetail — initial state and rendering', () => {
 
   it('renders the reading rows for the current year', async () => {
     const { findByText } = renderFresh()
-    const formatted = dayjs(READINGS_LIST[0].startDate).format('DD/MM/YYYY')
+    // La API devuelve descendente; READINGS_LIST[2] es la lectura más reciente
+    const formatted = dayjs(READINGS_LIST[2].startDate).format('DD/MM/YYYY')
     expect(await findByText(formatted)).toBeDefined()
   })
 
@@ -110,18 +111,19 @@ describe('Flow: reading CRUD in SupplyDetail', () => {
 
   it('click edit reading button opens form in edit mode with pre-filled values', async () => {
     const { findByText, findAllByRole } = renderFresh()
-    await findByText(dayjs(READINGS_LIST[0].startDate).format('DD/MM/YYYY'))
+    // Primera fila = lectura más reciente (índice 2 en orden ascendente)
+    await findByText(dayjs(READINGS_LIST[2].startDate).format('DD/MM/YYYY'))
 
     const editBtns = await findAllByRole('button', { name: /editar lectura/i })
     editBtns[0].click()
 
     expect(await findByText('Editar lectura')).toBeDefined()
-    expect(await findByText(String(READINGS_LIST[0].consumption))).toBeDefined()
+    expect(await findByText(String(READINGS_LIST[2].consumption))).toBeDefined()
   })
 
   it('edit reading → submit → modal closes', async () => {
     const { findByText, findAllByRole, queryByText } = renderFresh()
-    await findByText(dayjs(READINGS_LIST[0].startDate).format('DD/MM/YYYY'))
+    await findByText(dayjs(READINGS_LIST[2].startDate).format('DD/MM/YYYY'))
 
     const editBtns = await findAllByRole('button', { name: /editar lectura/i })
     editBtns[0].click()
@@ -134,13 +136,13 @@ describe('Flow: reading CRUD in SupplyDetail', () => {
 
   it('delete reading → confirm → row disappears from the table', async () => {
     const { findByText, findByRole, findAllByRole, queryByText } = renderFresh()
-    const firstDate = dayjs(READINGS_LIST[0].startDate).format('DD/MM/YYYY')
-    // Wait for initial load before overriding the handler
+    // Primera fila = lectura más reciente
+    const firstDate = dayjs(READINGS_LIST[2].startDate).format('DD/MM/YYYY')
     await findByText(firstDate)
 
     server.use(
       http.delete('/supplies/readings/:id', () => new HttpResponse(null, { status: 204 })),
-      http.get('/supplies/readings/supply/:supplyId', () => HttpResponse.json(READINGS_LIST.slice(1)))
+      http.get('/supplies/readings/supply/:supplyId', () => HttpResponse.json(READINGS_LIST.slice(0, 2).toSorted((a, b) => b.startDate - a.startDate || b.endDate - a.endDate)))
     )
 
     const deleteBtns = await findAllByRole('button', { name: /eliminar lectura/i })
@@ -157,7 +159,7 @@ describe('Flow: reading CRUD in SupplyDetail', () => {
       http.delete('/supplies/readings/:id', () => HttpResponse.json({}, { status: 500 }))
     )
     const { findByText, findByRole, findAllByRole } = renderFresh()
-    const firstDate = dayjs(READINGS_LIST[0].startDate).format('DD/MM/YYYY')
+    const firstDate = dayjs(READINGS_LIST[2].startDate).format('DD/MM/YYYY')
     await findByText(firstDate)
 
     const deleteBtns = await findAllByRole('button', { name: /eliminar lectura/i })


### PR DESCRIPTION
- Forzar orden descendente en la API por startDate y endDate (más reciente primero).
- Actualizar el mock de MSW para devolver lecturas ordenadas descendente en tests de cliente.
- Actualizar pruebas que dependían del orden antiguo.