### PR TITLE
fix(budget): prevent duplicate entries and fix layout shift on edit

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/api/src/controllers/budget.controller.ts
+++ b/packages/api/src/controllers/budget.controller.ts
@@ -50,12 +50,12 @@ export class BudgetController {
 
   public async copy (req: Request, res: Response, next: NextFunction): Promise<void> {
     Promise.resolve(req as RequestUser)
-      .tap(() => this.logger.logInfo('/copy - badget'))
+      .tap(() => this.logger.logInfo('/copy - budget'))
       .then(validateBudgetCopy)
       .then(this.budgetService.copy.bind(this.budgetService))
       .tap(() => this.logger.logInfo('Budget has been succesfully copied'))
       .then((response) => {
-        if (response === null) {
+        if (!response) {
           res.status(204).send()
         } else {
           res.status(201).send()

--- a/packages/api/src/services/budget.service.ts
+++ b/packages/api/src/services/budget.service.ts
@@ -180,7 +180,7 @@ export default class BudgetService implements IBudgetService {
     year,
     user
   }: { monthOrigin: number, yearOrigin: number, month: number, year: number, user: string }): Promise<boolean> {
-    const budgets = await BudgetModel.find({ user, month: monthOrigin, year: yearOrigin })
+    const budgets = await BudgetModel.find({ user, month: monthOrigin, year: yearOrigin }, 'category amount').lean()
 
     if (!budgets.length) {
       return false
@@ -194,7 +194,7 @@ export default class BudgetService implements IBudgetService {
       }
     }))
 
-    await BudgetModel.bulkWrite(operations as any)
+    await BudgetModel.bulkWrite(operations as mongoose.AnyBulkWriteOperation<IBudget>[])
     return true
   }
 }

--- a/packages/api/src/services/budget.service.ts
+++ b/packages/api/src/services/budget.service.ts
@@ -27,7 +27,7 @@ export interface IBudgetService {
     month,
     year,
     user
-  }: { monthOrigin: number, yearOrigin: number, month: number, year: number, user: string }): Promise<IBudget[] | null>
+  }: { monthOrigin: number, yearOrigin: number, month: number, year: number, user: string }): Promise<boolean>
 }
 
 export default class BudgetService implements IBudgetService {
@@ -166,33 +166,35 @@ export default class BudgetService implements IBudgetService {
     }
   }
 
-  async editBudget ({ category, year, month, user, amount }: IBudget): Promise<IBudget> {
+  public async editBudget ({ category, year, month, user, amount }: IBudget): Promise<IBudget> {
     return await BudgetModel.findOneAndUpdate({ category, year, month, user }, { amount }, {
       returnDocument: 'after',
       upsert: true
     }) as unknown as IBudget
   }
 
-  async copy ({
+  public async copy ({
     monthOrigin,
     yearOrigin,
     month,
     year,
     user
-  }: { monthOrigin: number, yearOrigin: number, month: number, year: number, user: string }): Promise<IBudget[] | null> {
+  }: { monthOrigin: number, yearOrigin: number, month: number, year: number, user: string }): Promise<boolean> {
     const budgets = await BudgetModel.find({ user, month: monthOrigin, year: yearOrigin })
-    const copyBudgets = budgets.map(budget => ({
-      year,
-      month,
-      category: budget.category,
-      amount: budget.amount,
-      user
-    }))
 
-    if (!copyBudgets.length) {
-      return null
+    if (!budgets.length) {
+      return false
     }
 
-    return BudgetModel.insertMany(copyBudgets)
+    const operations = budgets.map(budget => ({
+      updateOne: {
+        filter: { category: budget.category, year, month, user },
+        update: { $set: { amount: budget.amount } },
+        upsert: true
+      }
+    }))
+
+    await BudgetModel.bulkWrite(operations as any)
+    return true
   }
 }

--- a/packages/api/test/insert-data-to-model.ts
+++ b/packages/api/test/insert-data-to-model.ts
@@ -234,11 +234,13 @@ export const insertSupply = async (params: Record<string, any> = {}): Promise<IS
 export const insertSupplyReading = async (params: Record<string, any> = {}): Promise<ISupplyReading & { _id: any }> => {
   const user = (params.user ?? generateUsername()) as string
   const supplyId = params.supplyId ?? (await insertSupply({ user }))._id
+  const startDate = params.startDate ?? faker.date.past({ years: 1 }).getTime()
+  const endDate = params.endDate ?? faker.date.between({ from: startDate, to: Date.now() }).getTime()
 
   return SupplyReadingModel.create({
     supplyId,
-    startDate: params.startDate ?? faker.date.past().getTime(),
-    endDate: params.endDate ?? faker.date.recent().getTime(),
+    startDate,
+    endDate,
     amount: params.amount ?? faker.number.float({ min: -50, max: 250, multipleOf: 0.01 }),
     consumptionPeak: params.consumptionPeak ?? faker.number.int({ min: 10, max: 100 }),
     consumptionFlat: params.consumptionFlat ?? faker.number.int({ min: 10, max: 100 }),

--- a/packages/api/test/routes/budget.routes.test.ts
+++ b/packages/api/test/routes/budget.routes.test.ts
@@ -207,7 +207,7 @@ describe('Budget', () => {
         })
     })
 
-    test('when budget not exists, it should response with status code 200', async () => {
+    test('when budget not exists, it should create it and response with status code 200', async () => {
       const params = {
         category: category._id.toString(),
         month: faker.number.int({ min: 0, max: 11 }),
@@ -322,6 +322,34 @@ describe('Budget', () => {
         const newBudget = newBudgets.find(newBudget => newBudget.category.toString() === budget.category._id.toString())
         expect(newBudget?.amount).toBe(budget.amount)
       }
+    })
+
+    test('when copying twice to the same month, it should not create duplicates', async () => {
+      const monthOrigin = faker.number.int({ min: 0, max: 11 })
+      const yearOrigin = faker.number.int({ min: 2000, max: 2100 })
+      const numBudgets = 3
+      const oldBudgets = await Promise.all(Array.from({ length: numBudgets }, () => insertBudget({
+        user,
+        month: monthOrigin,
+        year: yearOrigin
+      })))
+
+      const body = {
+        month: faker.number.int({ min: 0, max: 11 }),
+        year: faker.number.int({ min: 2000, max: 2100 }),
+        monthOrigin,
+        yearOrigin
+      }
+
+      // First copy
+      await supertest(server.app).post(path).auth(token, { type: 'bearer' }).send(body).expect(201)
+
+      // Second copy to the same month
+      await supertest(server.app).post(path).auth(token, { type: 'bearer' }).send(body).expect(201)
+
+      // Verify no duplicates were created
+      const finalBudgets = await BudgetModel.find({ year: body.year, month: body.month, user })
+      expect(finalBudgets.length).toBe(oldBudgets.length)
     })
   })
 })

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/pages/Budgets/components/BudgetTable.tsx
+++ b/packages/client/src/pages/Budgets/components/BudgetTable.tsx
@@ -46,8 +46,8 @@ const BudgetTable = ({
             }
           ]}
         />
+        {selectedBudget && <ModalEdit onClose={handleCloseEdit} budget={selectedBudget} month={month} year={year} />}
       </Grid>
-      {selectedBudget && <ModalEdit onClose={handleCloseEdit} budget={selectedBudget} month={month} year={year} />}
     </>
   )
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-models",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Models for finper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/models/src/models/budgets.ts
+++ b/packages/models/src/models/budgets.ts
@@ -18,4 +18,6 @@ const budgetSchema = new Schema<IBudget>({
   user: { type: String, required: true }
 }, { versionKey: false })
 
+budgetSchema.index({ category: 1, year: 1, month: 1, user: 1 }, { unique: true })
+
 export const BudgetModel = model<IBudget>('Budget', budgetSchema)


### PR DESCRIPTION
## Problema

Al editar un presupuesto se creaban registros duplicados en la BD en lugar de actualizar el existente. Además, al abrir el modal de edición en la tabla de gastos, la tabla de ingresos desaparecía por un problema de layout.

## Causa raíz

1. **Duplicados en BD**: La función `copy()` usaba `insertMany` sin verificar existencia previa, creando duplicados si se copiaba el mismo mes dos veces.
2. **Layout shift**: El `ModalEdit` se renderizaba como hijo directo del `Grid container`, ocupando una celda del grid al montarse y desplazando la tabla de ingresos.

## Cambios

### packages/models
- Añadido índice único compuesto en BudgetModel para prevenir duplicados a nivel de BD.

### packages/api
- budget.service.ts: Refactorizado copy() para usar bulkWrite con updateOne y upsert en lugar de insertMany. Copiar dos veces al mismo mes actualiza en lugar de duplicar. Cambiado tipo de retorno a Promise boolean.
- budget.controller.ts: Actualizado el handler de copy() para usar !response. Corregido typo en log (badget a budget).
- budget.routes.test.ts: Actualizado test de edición y añadido nuevo test que verifica que copiar dos veces no crea duplicados.

### packages/client
- BudgetTable.tsx: Movido ModalEdit dentro del Grid item para que no sea un hijo directo del Grid container y no cause layout shift al abrirse.

## Nota de despliegue
Limpiar duplicados existentes en la BD antes de desplegar (el nuevo índice único fallará si hay duplicados previos).

