### PR TITLE
feat: add seed-user script to create initial user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# ── Base de datos ────────────────────────────────────────────────────────────
+DATABASE_NAME=finper
+DATABASE_HOST=127.0.0.1
+MONGODB_USER=
+MONGODB_PASS=
+
+# URI completa de MongoDB (opcional, sobreescribe DATABASE_HOST/USER/PASS)
+# MONGODB=mongodb://root:changeme@127.0.0.1:27017/finper?retryWrites=true&w=majority
+
+# ── Autenticación JWT ────────────────────────────────────────────────────────
+JWT_SECRET=change_this_secret
+SALT_ROUNDS=10
+
+# ── Logging (Grafana Loki) — opcional ────────────────────────────────────────
+GRAFANA_LOGGER_USER=
+GRAFANA_LOGGER_PASSWORD=
+
+# ── Ticket bot — opcional ────────────────────────────────────────────────────
+TICKET_BOT_URL=
+TICKET_BOT_API_KEY=

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,14 @@ define help
     lint-api:                  lint the API
     lint-client:               lint the client
     lint-models:               lint the models.
+    seed-user:                 create initial user (USERNAME and PASSWORD required).
     test:                      run all tests.
     test-api:                  run all tests for the API.
     test-client:               run all tests for the client
     test-models:               run all tests for the models.
     start-api:                 launch api
     start-client:              launch client
-    clean:                    clean all build artifacts.
+    clean:                     clean all build artifacts.
 
 endef
 export help
@@ -44,6 +45,9 @@ lint-models:
 	@pnpm --filter @soker90/finper-models lint
 
 ## API ##
+seed-user:
+	@INIT_USERNAME=$(USERNAME) INIT_PASSWORD=$(PASSWORD) pnpm --filter @soker90/finper-api seed-user
+
 start-api:
 	@pnpm --filter @soker90/finper-api start
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,38 @@ Para arrancar el proyecto, necesitaras añadir las siguientes variables a tu arc
 
 `MONGODB` - Optional
 
+## Gestión de usuarios
+
+### Opción A — Script manual (desarrollo local)
+
+Con la API arrancada y la base de datos accesible:
+
+```bash
+make seed-user USERNAME=miusuario PASSWORD=mipassword
+```
+
+### Opción B — Endpoint REST `/api/auth/register`
+
+El endpoint está abierto y permite crear usuarios adicionales en cualquier momento.
+
+```bash
+curl -X POST http://localhost:3008/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username": "miusuario", "password": "mipassword"}'
+```
+
+Respuesta exitosa (`200 OK`):
+
+```json
+{ "token": "<jwt>" }
+```
+
+> **Reglas de validación:**
+> - `username`: entre 3 y 15 caracteres
+> - `password`: mínimo 5 caracteres
+
+---
+
 ## Arrancar en local
 
 Es necesario tener previamente instalado node 16 y mongodb arrancado.
@@ -94,4 +126,3 @@ make
 ## Licencia
 
 [GPLv3 o Superior](https://github.com/soker90/finper/blob/master/LICENSE)
-

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,8 @@
     "build-ts": "tsc",
     "test": "NODE_ENV=test jest --maxWorkers=50% --silent",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --fix --ext .ts"
+    "lint:fix": "eslint . --fix --ext .ts",
+    "seed-user": "ts-node src/scripts/seed-user.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/api/src/scripts/seed-user.ts
+++ b/packages/api/src/scripts/seed-user.ts
@@ -34,7 +34,7 @@ async function seed (): Promise<void> {
   const existing = await UserModel.findOne({ username })
 
   if (existing) {
-    console.log(`ℹ️   El usuario "${username}" ya existe. No se realizaron cambios.`)
+    console.log('ℹ️   El usuario ya existe. No se realizaron cambios.')
     await mongoose.connection.close()
     process.exit(0)
   }

--- a/packages/api/src/scripts/seed-user.ts
+++ b/packages/api/src/scripts/seed-user.ts
@@ -1,0 +1,52 @@
+import 'dotenv/config'
+import { UserModel, mongoose } from '@soker90/finper-models'
+import config from '../config'
+import db from '../config/db'
+import { MIN_LENGTH_USERNAME, MAX_USERNAME_LENGTH, MIN_PASSWORD_LENGTH } from '../config/inputs'
+
+const username = (process.env.INIT_USERNAME ?? '').toLowerCase().trim()
+const password = process.env.INIT_PASSWORD ?? ''
+
+function validate (): void {
+  if (!username || username.length < MIN_LENGTH_USERNAME || username.length > MAX_USERNAME_LENGTH) {
+    console.error(
+      `❌  INIT_USERNAME es obligatorio y debe tener entre ${MIN_LENGTH_USERNAME} y ${MAX_USERNAME_LENGTH} caracteres.`
+    )
+    process.exit(1)
+  }
+
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    console.error(`❌  INIT_PASSWORD es obligatorio y debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres.`)
+    process.exit(1)
+  }
+}
+
+async function seed (): Promise<void> {
+  validate()
+
+  db.connect(config.mongo)
+
+  await new Promise<void>((resolve, reject) => {
+    mongoose.connection.once('connected', resolve)
+    mongoose.connection.once('error', reject)
+  })
+
+  const existing = await UserModel.findOne({ username })
+
+  if (existing) {
+    console.log(`ℹ️   El usuario "${username}" ya existe. No se realizaron cambios.`)
+    await mongoose.connection.close()
+    process.exit(0)
+  }
+
+  await UserModel.create({ username, password })
+  console.log(`✅  Usuario "${username}" creado correctamente.`)
+
+  await mongoose.connection.close()
+  process.exit(0)
+}
+
+seed().catch((err: unknown) => {
+  console.error('❌  Error inesperado:', err)
+  process.exit(1)
+})

--- a/packages/api/src/scripts/seed-user.ts
+++ b/packages/api/src/scripts/seed-user.ts
@@ -40,7 +40,7 @@ async function seed (): Promise<void> {
   }
 
   await UserModel.create({ username, password })
-  console.log(`✅  Usuario "${username}" creado correctamente.`)
+  console.log('✅  Usuario creado correctamente.')
 
   await mongoose.connection.close()
   process.exit(0)


### PR DESCRIPTION
## ¿Qué incluye esta PR?
### Script de seed para el usuario inicial
- Nuevo script `packages/api/src/scripts/seed-user.ts` que conecta a MongoDB y crea un usuario a partir de las variables de entorno `INIT_USERNAME` e `INIT_PASSWORD`
- Es **idempotente**: si el usuario ya existe, termina con éxito sin hacer nada
- Valida que las credenciales cumplan las reglas del proyecto (longitud de username y password)
### Integración en el flujo de trabajo
- Nuevo script `seed-user` en `packages/api/package.json`
- Nuevo target `make seed-user USERNAME=x PASSWORD=y` en el `Makefile`
### Documentación
- Sección **Gestión de usuarios** añadida al `README.md` con ejemplos de `make` y `curl`
- Nuevo `.env.example` con todas las variables de entorno necesarias
## Uso
```bash
make seed-user USERNAME=miusuario PASSWORD=mipassword
```