### PR TITLE
feat(tariffs): add social bonus, discounts, firstYearTotal and cost column

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/api/src/services/tariffs.service.ts
+++ b/packages/api/src/services/tariffs.service.ts
@@ -245,15 +245,18 @@ export default class TariffsService implements ITariffsService {
     const estimatedAnnualTotal = Number(invoices.reduce((total, invoice) => total + invoice.newTariffSimulatedAmount, 0).toFixed(2))
     const currentTotalSimulated = invoices.reduce((total, invoice) => total + invoice.currentTariffSimulatedAmount, 0)
 
-    // Calcular coste del primer año con descuento (si existe y tiene duración definida)
+    // Calcular coste del primer año con descuento:
+    // - meses === null significa descuento permanente → se aplica el año completo (12 meses)
+    // - meses > 12 → se limita a 12 para no descontar más de un año
     let firstYearTotal: number | null = null
     const { discount } = tariff
-    if (discount && discount.meses) {
+    if (discount) {
+      const mesesPrimerAno = discount.meses === null ? 12 : Math.min(discount.meses, 12)
       if (discount.tipo === 'porcentaje') {
-        const descuentoEuros = estimatedAnnualTotal * (discount.meses / 12) * (discount.valor / 100)
+        const descuentoEuros = estimatedAnnualTotal * (mesesPrimerAno / 12) * (discount.valor / 100)
         firstYearTotal = Number((estimatedAnnualTotal - descuentoEuros).toFixed(2))
       } else {
-        const numPeriodos = discount.meses / tariff.billingMonths
+        const numPeriodos = mesesPrimerAno / (tariff.billingMonths || 12)
         firstYearTotal = Number((estimatedAnnualTotal - discount.valor * numPeriodos).toFixed(2))
       }
     }

--- a/packages/api/src/services/tariffs.service.ts
+++ b/packages/api/src/services/tariffs.service.ts
@@ -87,6 +87,13 @@ interface ISimulatedInvoice {
 export interface TariffComparisonResult {
   retailer: string
   tariffName: string
+  billingMonths: number
+  discount: {
+    tipo: 'porcentaje' | 'fijo'
+    valor: number
+    meses: number | null
+    soloNuevosClientes: boolean
+  } | null
   peakPower: number
   offPeakPower: number
   peakEnergy: number
@@ -117,9 +124,7 @@ export default class TariffsService implements ITariffsService {
         socialBonusPerDay: apiData.datosGenerales.bonoSocial ?? 0
       },
       tariffs: apiData.tarifas.map(entry => {
-        const includesSocialBonus = entry.detalles.incluyeBonoSocial !== undefined && entry.detalles.incluyeBonoSocial !== null
-          ? entry.detalles.incluyeBonoSocial
-          : !['enérgya', 'energya'].some(n => entry.comercializadora.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').includes(n))
+        const includesSocialBonus = entry.detalles.incluyeBonoSocial !== false
 
         return {
           retailer: entry.comercializadora,
@@ -178,7 +183,7 @@ export default class TariffsService implements ITariffsService {
       user,
       endDate: { $lte: lastReading.endDate },
       startDate: { $gte: lastReading.endDate - ONE_YEAR_MS }
-    })
+    }).sort({ endDate: -1 })
 
     if (readings.length === 0) {
       throw Boom.badRequest(ERROR_MESSAGE.SUPPLY_READING.NO_READINGS_IN_LAST_YEAR).output
@@ -223,7 +228,7 @@ export default class TariffsService implements ITariffsService {
     const newTariffPrices: ITariffPrices = { peakPower, offPeakPower, peakEnergy, flatEnergy, offPeakEnergy }
 
     const invoices: ISimulatedInvoice[] = readings.map(reading => {
-      const billedDays = (reading.endDate - reading.startDate) / (1000 * 60 * 60 * 24)
+      const billedDays = Math.max(1, Math.round((reading.endDate - reading.startDate) / (1000 * 60 * 60 * 24)))
       return {
         startDate: reading.startDate,
         endDate: reading.endDate,
@@ -256,6 +261,8 @@ export default class TariffsService implements ITariffsService {
     return {
       retailer: tariff.retailer,
       tariffName: tariff.tariffName,
+      billingMonths: tariff.billingMonths,
+      discount: tariff.discount,
       peakPower,
       offPeakPower,
       peakEnergy,

--- a/packages/api/src/services/tariffs.service.ts
+++ b/packages/api/src/services/tariffs.service.ts
@@ -12,6 +12,7 @@ interface ITariffApiResponse {
     iva: number
     impuestoElectrico: number
     alquilerContador: number
+    bonoSocial: number
   }
   tarifas: Array<{
     comercializadora: string
@@ -23,6 +24,14 @@ interface ITariffApiResponse {
       energiaPunta: number
       energiaLlana: number
       energiaValle: number
+      mantenimientoPrecio?: number
+      incluyeBonoSocial?: boolean
+      descuento?: {
+        tipo: 'porcentaje' | 'fijo'
+        valor: number
+        meses: number | null
+        soloNuevosClientes?: boolean
+      } | null
     }
   }>
 }
@@ -41,12 +50,23 @@ interface ITaxConfig {
   vat: number
   electricityTax: number
   meterRental: number
+  socialBonusPerDay: number
+}
+
+interface IDiscount {
+  tipo: 'porcentaje' | 'fijo'
+  valor: number
+  meses: number | null
+  soloNuevosClientes: boolean
 }
 
 interface ITariffEntry {
   retailer: string
   tariffName: string
+  billingMonths: number
   prices: ITariffPrices
+  includesSocialBonus: boolean
+  discount: IDiscount | null
 }
 
 interface ITariffData {
@@ -74,6 +94,7 @@ export interface TariffComparisonResult {
   offPeakEnergy: number
   estimatedAnnualTotal: number
   estimatedAnnualSavings: number
+  firstYearTotal: number | null
   invoices: ISimulatedInvoice[]
 }
 
@@ -92,19 +113,31 @@ export default class TariffsService implements ITariffsService {
       taxes: {
         vat: apiData.datosGenerales.iva,
         electricityTax: apiData.datosGenerales.impuestoElectrico,
-        meterRental: apiData.datosGenerales.alquilerContador
+        meterRental: apiData.datosGenerales.alquilerContador,
+        socialBonusPerDay: apiData.datosGenerales.bonoSocial ?? 0
       },
-      tariffs: apiData.tarifas.map(entry => ({
-        retailer: entry.comercializadora,
-        tariffName: entry.detalles.nombreTarifa,
-        prices: {
-          peakPower: entry.detalles.potenciaPunta,
-          offPeakPower: entry.detalles.potenciaValle,
-          peakEnergy: entry.detalles.energiaPunta,
-          flatEnergy: entry.detalles.energiaLlana,
-          offPeakEnergy: entry.detalles.energiaValle
+      tariffs: apiData.tarifas.map(entry => {
+        const includesSocialBonus = entry.detalles.incluyeBonoSocial !== undefined && entry.detalles.incluyeBonoSocial !== null
+          ? entry.detalles.incluyeBonoSocial
+          : !['enérgya', 'energya'].some(n => entry.comercializadora.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').includes(n))
+
+        return {
+          retailer: entry.comercializadora,
+          tariffName: entry.detalles.nombreTarifa,
+          billingMonths: entry.detalles.mantenimientoPrecio ?? 12,
+          prices: {
+            peakPower: entry.detalles.potenciaPunta,
+            offPeakPower: entry.detalles.potenciaValle,
+            peakEnergy: entry.detalles.energiaPunta,
+            flatEnergy: entry.detalles.energiaLlana,
+            offPeakEnergy: entry.detalles.energiaValle
+          },
+          includesSocialBonus,
+          discount: entry.detalles.descuento
+            ? { ...entry.detalles.descuento, soloNuevosClientes: entry.detalles.descuento.soloNuevosClientes ?? false }
+            : null
         }
-      }))
+      })
     }
   }
 
@@ -160,7 +193,8 @@ export default class TariffsService implements ITariffsService {
     contractedPowerOffPeak: number,
     prices: ITariffPrices,
     billedDays: number,
-    taxes: ITaxConfig
+    taxes: ITaxConfig,
+    includesSocialBonus: boolean
   ): number {
     const powerCost =
       ((contractedPowerPeak * prices.peakPower) + (contractedPowerOffPeak * prices.offPeakPower)) * billedDays
@@ -168,8 +202,13 @@ export default class TariffsService implements ITariffsService {
       ((reading.consumptionPeak || 0) * prices.peakEnergy) +
       ((reading.consumptionFlat || 0) * prices.flatEnergy) +
       ((reading.consumptionOffPeak || 0) * prices.offPeakEnergy)
-    const subtotal = (powerCost + energyCost) * (1 + taxes.electricityTax)
-    return (subtotal + (taxes.meterRental * billedDays)) * (1 + taxes.vat)
+    // Impuesto Eléctrico: MAX(totalKWh × 0.001, (potencia + energía) × IEact)
+    const totalKwh = (reading.consumptionPeak || 0) + (reading.consumptionFlat || 0) + (reading.consumptionOffPeak || 0)
+    const electricityTaxAmount = Math.max(totalKwh * 0.001, (powerCost + energyCost) * taxes.electricityTax)
+    const socialBonusAmount = includesSocialBonus ? taxes.socialBonusPerDay * billedDays : 0
+    // TotalBruto = potencia + energía + impEléctrico + alquilerContador [+ bonoSocial]
+    const totalBruto = powerCost + energyCost + electricityTaxAmount + (taxes.meterRental * billedDays) + socialBonusAmount
+    return totalBruto * (1 + taxes.vat)
   }
 
   private simulateTariff (
@@ -190,16 +229,29 @@ export default class TariffsService implements ITariffsService {
         endDate: reading.endDate,
         realAmount: reading.amount,
         currentTariffSimulatedAmount: Number(
-          this.calculateInvoiceCost(reading, contractedPowerPeak, contractedPowerOffPeak, currentTariffPrices, billedDays, taxes).toFixed(2)
+          this.calculateInvoiceCost(reading, contractedPowerPeak, contractedPowerOffPeak, currentTariffPrices, billedDays, taxes, tariff.includesSocialBonus).toFixed(2)
         ),
         newTariffSimulatedAmount: Number(
-          this.calculateInvoiceCost(reading, contractedPowerPeak, contractedPowerOffPeak, newTariffPrices, billedDays, taxes).toFixed(2)
+          this.calculateInvoiceCost(reading, contractedPowerPeak, contractedPowerOffPeak, newTariffPrices, billedDays, taxes, tariff.includesSocialBonus).toFixed(2)
         )
       }
     })
 
     const estimatedAnnualTotal = Number(invoices.reduce((total, invoice) => total + invoice.newTariffSimulatedAmount, 0).toFixed(2))
     const currentTotalSimulated = invoices.reduce((total, invoice) => total + invoice.currentTariffSimulatedAmount, 0)
+
+    // Calcular coste del primer año con descuento (si existe y tiene duración definida)
+    let firstYearTotal: number | null = null
+    const { discount } = tariff
+    if (discount && discount.meses) {
+      if (discount.tipo === 'porcentaje') {
+        const descuentoEuros = estimatedAnnualTotal * (discount.meses / 12) * (discount.valor / 100)
+        firstYearTotal = Number((estimatedAnnualTotal - descuentoEuros).toFixed(2))
+      } else {
+        const numPeriodos = discount.meses / tariff.billingMonths
+        firstYearTotal = Number((estimatedAnnualTotal - discount.valor * numPeriodos).toFixed(2))
+      }
+    }
 
     return {
       retailer: tariff.retailer,
@@ -211,6 +263,7 @@ export default class TariffsService implements ITariffsService {
       offPeakEnergy,
       estimatedAnnualTotal,
       estimatedAnnualSavings: Number((currentTotalSimulated - estimatedAnnualTotal).toFixed(2)),
+      firstYearTotal,
       invoices
     }
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/hooks/useTariffsComparison.ts
+++ b/packages/client/src/hooks/useTariffsComparison.ts
@@ -11,6 +11,13 @@ export interface TariffComparison {
   offPeakEnergy: number
   estimatedAnnualTotal: number
   estimatedAnnualSavings: number
+  firstYearTotal: number | null
+  discount?: {
+    tipo: 'porcentaje' | 'fijo'
+    valor: number
+    meses: number | null
+    soloNuevosClientes: boolean
+  } | null
   invoices: Array<{
     startDate: number
     endDate: number

--- a/packages/client/src/hooks/useTariffsComparison.ts
+++ b/packages/client/src/hooks/useTariffsComparison.ts
@@ -4,6 +4,13 @@ import { TARIFFS_COMPARISON } from 'constants/api-paths'
 export interface TariffComparison {
   retailer: string
   tariffName: string
+  billingMonths: number
+  discount: {
+    tipo: 'porcentaje' | 'fijo'
+    valor: number
+    meses: number | null
+    soloNuevosClientes: boolean
+  } | null
   peakPower: number
   offPeakPower: number
   peakEnergy: number
@@ -12,12 +19,6 @@ export interface TariffComparison {
   estimatedAnnualTotal: number
   estimatedAnnualSavings: number
   firstYearTotal: number | null
-  discount?: {
-    tipo: 'porcentaje' | 'fijo'
-    valor: number
-    meses: number | null
-    soloNuevosClientes: boolean
-  } | null
   invoices: Array<{
     startDate: number
     endDate: number

--- a/packages/client/src/pages/Supplies/components/SupplyForm/config.ts
+++ b/packages/client/src/pages/Supplies/components/SupplyForm/config.ts
@@ -4,7 +4,6 @@ export const SUPPLY_TYPE_OPTIONS: { value: SupplyType; label: string }[] = [
   { value: 'electricity', label: 'Electricidad' },
   { value: 'water', label: 'Agua' },
   { value: 'gas', label: 'Gas' },
-  { value: 'internet', label: 'Internet' },
   { value: 'other', label: 'Otro' }
 ]
 

--- a/packages/client/src/pages/Supplies/utils/supply.ts
+++ b/packages/client/src/pages/Supplies/utils/supply.ts
@@ -6,7 +6,6 @@ export const SUPPLY_TYPE_LABELS: Record<SupplyType, string> = {
   electricity: 'Electricidad',
   water: 'Agua',
   gas: 'Gas',
-  internet: 'Internet',
   other: 'Otro'
 }
 
@@ -14,15 +13,13 @@ export const SUPPLY_TYPE_COLORS: Record<string, 'warning' | 'info' | 'error' | '
   electricity: 'warning',
   water: 'info',
   gas: 'error',
-  internet: 'primary',
   other: 'default'
 }
 
 export const SUPPLY_TYPE_UNITS: Record<SupplyType, string> = {
   electricity: 'kWh',
   water: 'm³',
-  gas: 'kWh',
-  internet: '',
+  gas: 'm³',
   other: ''
 }
 

--- a/packages/client/src/pages/SupplyDetail/components/SupplyConsumptionChart.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/SupplyConsumptionChart.tsx
@@ -15,6 +15,7 @@ import dayjs from 'dayjs'
 
 import { MainCard } from 'components'
 import { SupplyReading } from 'types'
+import { getElectricityColors, ELECTRICITY_LABELS, CHART_GRID_PROPS, CHART_AXIS_PROPS } from './chartConfig'
 
 type Props = {
   readings: SupplyReading[]
@@ -24,10 +25,11 @@ type Props = {
 
 const SupplyConsumptionChart = ({ readings, isElectricity, unit }: Props) => {
   const theme = useTheme()
+  const colors = getElectricityColors(theme)
 
-  const data = useMemo(() => {
-    return readings
-      .toSorted((a, b) => a.startDate - b.startDate)
+  const data = useMemo(() =>
+    readings
+      .toReversed()
       .map((reading) => ({
         label: dayjs(reading.startDate).format('MM/YY'),
         consumption: reading.consumption ?? 0,
@@ -35,37 +37,35 @@ const SupplyConsumptionChart = ({ readings, isElectricity, unit }: Props) => {
         flat: reading.consumptionFlat ?? 0,
         offPeak: reading.consumptionOffPeak ?? 0
       }))
-  }, [readings])
+  , [readings])
 
   if (data.length === 0) return null
+
+  const unitSuffix = unit ? ` ${unit}` : ''
 
   return (
     <MainCard title='Gráfica de consumo'>
       <ResponsiveContainer width='100%' height={280}>
         <BarChart data={data}>
-          <CartesianGrid strokeDasharray='3 3' stroke={theme.palette.divider} />
-          <XAxis dataKey='label' tick={{ fontSize: 12 }} />
-          <YAxis
-            tick={{ fontSize: 12 }}
-            tickFormatter={(value) => `${value}${unit ? ` ${unit}` : ''}`}
-          />
-          <Tooltip />
+          <CartesianGrid {...CHART_GRID_PROPS} stroke={theme.palette.divider} />
+          <XAxis dataKey='label' {...CHART_AXIS_PROPS} />
+          <YAxis {...CHART_AXIS_PROPS} tickFormatter={(v) => `${v}${unitSuffix}`} />
+          <Tooltip formatter={(value, name) => [`${value}${unitSuffix}`, name]} />
           <Legend
             wrapperStyle={{ fontSize: 14 }}
             formatter={(value) => (
               <Typography component='span' variant='body2'>{value}</Typography>
             )}
           />
-
           {isElectricity
             ? (
               <>
-                <Bar dataKey='peak' name='Punta' stackId='consumption' fill={theme.palette.warning.main} radius={[4, 4, 0, 0]} />
-                <Bar dataKey='flat' name='Llano' stackId='consumption' fill={theme.palette.primary.main} radius={[4, 4, 0, 0]} />
-                <Bar dataKey='offPeak' name='Valle' stackId='consumption' fill={theme.palette.success.main} radius={[4, 4, 0, 0]} />
+                <Bar dataKey='peak' name={ELECTRICITY_LABELS.peak} stackId='consumption' fill={colors.peak} radius={[4, 4, 0, 0]} />
+                <Bar dataKey='flat' name={ELECTRICITY_LABELS.flat} stackId='consumption' fill={colors.flat} radius={[4, 4, 0, 0]} />
+                <Bar dataKey='offPeak' name={ELECTRICITY_LABELS.offPeak} stackId='consumption' fill={colors.offPeak} radius={[4, 4, 0, 0]} />
               </>
               )
-            : <Bar dataKey='consumption' name={`Consumo${unit ? ` (${unit})` : ''}`} fill={theme.palette.info.main} radius={[4, 4, 0, 0]} />}
+            : <Bar dataKey='consumption' name={`Consumo${unitSuffix}`} fill={theme.palette.info.main} radius={[4, 4, 0, 0]} />}
         </BarChart>
       </ResponsiveContainer>
     </MainCard>

--- a/packages/client/src/pages/SupplyDetail/components/SupplyTrendChart.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/SupplyTrendChart.tsx
@@ -1,0 +1,126 @@
+import { useState, useMemo, useCallback } from 'react'
+import { Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import type { LegendPayload } from 'recharts'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts'
+import dayjs from 'dayjs'
+
+import { MainCard } from 'components'
+import { SupplyReading } from 'types'
+import { getElectricityColors, ELECTRICITY_LABELS, CHART_GRID_PROPS, CHART_AXIS_PROPS } from './chartConfig'
+
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000
+
+type Props = {
+  readings: SupplyReading[]
+  isElectricity: boolean
+  unit: string
+}
+
+const ELEC_KEYS = ['peak', 'flat', 'offPeak'] as const
+type ElecKey = typeof ELEC_KEYS[number]
+
+const isElecKey = (key: unknown): key is ElecKey =>
+  ELEC_KEYS.includes(key as ElecKey)
+
+const DEFAULT_OPACITY: Record<ElecKey, number> = { peak: 1, flat: 1, offPeak: 1 }
+const DIM_OPACITY: Record<ElecKey, number> = { peak: 0.2, flat: 0.2, offPeak: 0.2 }
+
+const SupplyTrendChart = ({ readings, isElectricity, unit }: Props) => {
+  const theme = useTheme()
+  const colors = getElectricityColors(theme)
+  const [opacity, setOpacity] = useState<Record<ElecKey, number>>(DEFAULT_OPACITY)
+
+  const data = useMemo(() => {
+    if (!readings.length) return []
+    const windowMs = isElectricity ? ONE_YEAR_MS : ONE_YEAR_MS * 2
+    const cutoff = readings[0].endDate - windowMs
+    return readings
+      .filter((r) => r.endDate >= cutoff)
+      .toReversed()
+      .map((r) => ({
+        label: dayjs(r.endDate).format('MM/YY'),
+        peak: r.consumptionPeak ?? 0,
+        flat: r.consumptionFlat ?? 0,
+        offPeak: r.consumptionOffPeak ?? 0,
+        consumption: r.consumption ?? 0
+      }))
+  }, [readings, isElectricity])
+
+  const handleLegendMouseEnter = useCallback((o: LegendPayload) => {
+    if (!isElecKey(o.dataKey)) return
+    setOpacity({ ...DIM_OPACITY, [o.dataKey]: 1 })
+  }, [])
+
+  const handleLegendMouseLeave = useCallback(() => setOpacity(DEFAULT_OPACITY), [])
+
+  if (data.length === 0) return null
+
+  const title = isElectricity ? 'Tendencia del Último Año' : 'Tendencia de los Últimos 2 Años'
+  const unitSuffix = unit ? ` ${unit}` : ''
+
+  return (
+    <MainCard title={title}>
+      <ResponsiveContainer width='100%' height={260}>
+        <LineChart data={data} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+          <CartesianGrid {...CHART_GRID_PROPS} stroke={theme.palette.divider} />
+          <XAxis dataKey='label' {...CHART_AXIS_PROPS} />
+          <YAxis {...CHART_AXIS_PROPS} tickFormatter={(v) => `${v}${unitSuffix}`} />
+          <Tooltip
+            formatter={(value, name) => [`${value}${unitSuffix}`, name]}
+            contentStyle={{ borderRadius: 8, border: 'none', boxShadow: theme.shadows[3] }}
+          />
+          {isElectricity
+            ? (
+              <>
+                <Legend
+                  iconType='circle'
+                  wrapperStyle={{ fontSize: 13, cursor: 'pointer' }}
+                  onMouseEnter={handleLegendMouseEnter}
+                  onMouseLeave={handleLegendMouseLeave}
+                  formatter={(value) => (
+                    <Typography component='span' variant='body2'>{value}</Typography>
+                  )}
+                />
+                {ELEC_KEYS.map((key) => (
+                  <Line
+                    key={key}
+                    type='monotone'
+                    dataKey={key}
+                    name={ELECTRICITY_LABELS[key]}
+                    stroke={colors[key]}
+                    strokeWidth={2}
+                    strokeOpacity={opacity[key]}
+                    dot={false}
+                    activeDot={{ r: 5 }}
+                  />
+                ))}
+              </>
+              )
+            : (
+              <Line
+                type='monotone'
+                dataKey='consumption'
+                name='Consumo'
+                stroke={theme.palette.info.main}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 5 }}
+              />
+              )}
+        </LineChart>
+      </ResponsiveContainer>
+    </MainCard>
+  )
+}
+
+export default SupplyTrendChart

--- a/packages/client/src/pages/SupplyDetail/components/TariffComparisonTable.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/TariffComparisonTable.tsx
@@ -24,7 +24,8 @@ const HEADER_COLUMNS = [
   { id: 'expand', label: '', align: 'left' as const, width: 40 },
   { id: 'tariff', label: 'Tarifa / Comercializadora', align: 'left' as const },
   { id: 'power', label: 'Potencia / Energía', align: 'center' as const },
-  { id: 'savings', label: 'Ahorro Anual Estimado', align: 'right' as const }
+  { id: 'cost', label: 'Coste Anual', align: 'right' as const },
+  { id: 'savings', label: 'Ahorro Estimado', align: 'right' as const }
 ]
 
 const TariffComparisonTable = ({ comparison, isLoading }: Props) => (

--- a/packages/client/src/pages/SupplyDetail/components/TariffPageHeader.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/TariffPageHeader.tsx
@@ -1,5 +1,5 @@
-import { Box, Button, Chip, Typography } from '@mui/material'
-import { ArrowLeftOutlined } from '@ant-design/icons'
+import { Box, Button, Chip, Stack, Typography } from '@mui/material'
+import { ArrowLeftOutlined, ThunderboltOutlined } from '@ant-design/icons'
 import { Supply } from 'types'
 
 interface Props {
@@ -10,17 +10,26 @@ interface Props {
 
 const TariffPageHeader = ({ propertyName, supply, onBack }: Props) => (
   <Box display='flex' alignItems='center' justifyContent='space-between' flexWrap='wrap' gap={1}>
-    <Box display='flex' alignItems='center' gap={1}>
+    <Box display='flex' alignItems='center' gap={1.5}>
       <Button startIcon={<ArrowLeftOutlined />} onClick={onBack} size='small'>
         Volver
       </Button>
-      <Box>
-        <Typography variant='h4'>{propertyName}</Typography>
-        <Typography variant='subtitle2' color='text.secondary'>
-          {supply ? (supply.name ? `${supply.name} · ${supply.type}` : supply.type) : ''}
-        </Typography>
-      </Box>
-      <Chip label='Comparar tarifas' color='primary' size='small' />
+      <Stack spacing={0.25}>
+        <Stack direction='row' alignItems='center' spacing={1}>
+          <Typography variant='h4'>{propertyName}</Typography>
+          <Chip
+            icon={<ThunderboltOutlined />}
+            label='Comparar tarifas'
+            color='primary'
+            size='small'
+          />
+        </Stack>
+        {supply?.name && (
+          <Typography variant='body2' color='text.secondary'>
+            {supply.name}
+          </Typography>
+        )}
+      </Stack>
     </Box>
   </Box>
 )

--- a/packages/client/src/pages/SupplyDetail/components/TariffRow.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/TariffRow.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import {
   Box,
   Collapse,
+  Chip,
   IconButton,
   Table,
   TableBody,
@@ -106,9 +107,20 @@ const TariffRow = ({ row, isBest }: Props) => {
             >
               {row.retailer}
             </Typography>
-            <Typography variant='body2' color='text.secondary'>
-              {row.tariffName}
-            </Typography>
+            <Stack direction='row' spacing={1} alignItems='center'>
+              <Typography variant='body2' color='text.secondary'>
+                {row.tariffName}
+              </Typography>
+              {row.discount && (
+                <Chip
+                  label={`${row.discount.tipo === 'porcentaje' ? '-' : ''}${row.discount.valor}${row.discount.tipo === 'porcentaje' ? '%' : '€'}${row.discount.meses ? ` / ${row.discount.meses}m` : ''}${row.discount.soloNuevosClientes ? ' ★nuevos' : ''}`}
+                  size='small'
+                  color='secondary'
+                  variant='outlined'
+                  sx={{ height: 16, fontSize: '0.65rem', fontWeight: 700 }}
+                />
+              )}
+            </Stack>
           </Stack>
         </TableCell>
         <TableCell align='center'>
@@ -122,19 +134,31 @@ const TariffRow = ({ row, isBest }: Props) => {
           </Stack>
         </TableCell>
         <TableCell align='right'>
+          <Stack alignItems='flex-end'>
+            <Typography variant='subtitle1' fontWeight={700}>
+              {format.euro(row.estimatedAnnualTotal)}
+            </Typography>
+            {row.firstYearTotal !== null && (
+              <Typography variant='caption' color='secondary' fontWeight={700}>
+                1er año: {format.euro(row.firstYearTotal)}
+              </Typography>
+            )}
+          </Stack>
+        </TableCell>
+        <TableCell align='right'>
           <Typography
             variant='h6'
             component='span'
             fontWeight={700}
             color={getSavingsColor(row.estimatedAnnualSavings)}
           >
-            {savingsLabel === 'saving' ? `${TARIFF_ROW_LABELS.saving}: ` : `${TARIFF_ROW_LABELS.cost}: `}
-            {format.euro(Math.abs(row.estimatedAnnualSavings))}{TARIFF_ROW_LABELS.savingsPerYear}
+            {savingsLabel === 'saving' ? '+' : ''}
+            {format.euro(row.estimatedAnnualSavings)}
           </Typography>
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={5}>
           <Collapse in={open} timeout='auto' unmountOnExit>
             <Box sx={{ margin: 2, bgcolor: 'grey.50', p: 2, borderRadius: 2 }}>
               <Typography variant='subtitle2' gutterBottom component='div' fontWeight={700}>

--- a/packages/client/src/pages/SupplyDetail/components/TariffRow.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/TariffRow.tsx
@@ -33,6 +33,19 @@ interface Props {
   isBest: boolean
 }
 
+const BILLING_MONTHS_LABEL: Record<number, string> = {
+  1: 'Mensual',
+  2: 'Bimensual',
+  3: 'Trimestral',
+  6: 'Semestral',
+  12: 'Anual',
+}
+
+const BILLING_MONTHS_COLOR: Record<number, 'warning' | 'success' | 'default' | 'info'> = {
+  3: 'warning',
+  12: 'success',
+}
+
 const TariffRow = ({ row, isBest }: Props) => {
   const [open, setOpen] = useState(false)
   const savingsLabel = getSavingsLabel(row.estimatedAnnualSavings)
@@ -111,6 +124,15 @@ const TariffRow = ({ row, isBest }: Props) => {
               <Typography variant='body2' color='text.secondary'>
                 {row.tariffName}
               </Typography>
+              {row.billingMonths && (
+                <Chip
+                  label={BILLING_MONTHS_LABEL[row.billingMonths] ?? `${row.billingMonths}m`}
+                  size='small'
+                  color={BILLING_MONTHS_COLOR[row.billingMonths] ?? 'default'}
+                  variant='outlined'
+                  sx={{ height: 16, fontSize: '0.65rem', fontWeight: 700 }}
+                />
+              )}
               {row.discount && (
                 <Chip
                   label={`${row.discount.tipo === 'porcentaje' ? '-' : ''}${row.discount.valor}${row.discount.tipo === 'porcentaje' ? '%' : '€'}${row.discount.meses ? ` / ${row.discount.meses}m` : ''}${row.discount.soloNuevosClientes ? ' ★nuevos' : ''}`}

--- a/packages/client/src/pages/SupplyDetail/components/WinnerCard.tsx
+++ b/packages/client/src/pages/SupplyDetail/components/WinnerCard.tsx
@@ -1,5 +1,5 @@
 import { TariffComparison } from 'hooks/useTariffsComparison'
-import { Box, Grid, Typography } from '@mui/material'
+import { Box, Grid, Typography, Chip, Stack } from '@mui/material'
 import { TrophyOutlined } from '@ant-design/icons'
 import { MainCard } from 'components'
 import { format } from 'utils'
@@ -43,9 +43,20 @@ const WinnerCard = ({ winner }: Props) => (
         <Typography variant='overline' color='success.main' fontWeight={800} letterSpacing={1.2}>
           RECOMENDACIÓN PERSONALIZADA
         </Typography>
-        <Typography variant='h3' fontWeight={800} gutterBottom>
-          {winner.retailer}
-        </Typography>
+        <Stack direction='row' spacing={2} alignItems='center' sx={{ mb: 2 }}>
+          <Typography variant='h3' fontWeight={800} sx={{ mb: 0 }}>
+            {winner.retailer}
+          </Typography>
+          {winner.discount && (
+            <Chip
+              label={`${winner.discount.tipo === 'porcentaje' ? '-' : ''}${winner.discount.valor}${winner.discount.tipo === 'porcentaje' ? '%' : '€'}${winner.discount.meses ? ` / ${winner.discount.meses}m` : ''}${winner.discount.soloNuevosClientes ? ' ★nuevos' : ''}`}
+              color='secondary'
+              variant='filled'
+              size='small'
+              sx={{ fontWeight: 800 }}
+            />
+          )}
+        </Stack>
         <Typography variant='h6' color='text.secondary' fontWeight={500}>
           Tarifa: {winner.tariffName}
         </Typography>
@@ -68,9 +79,15 @@ const WinnerCard = ({ winner }: Props) => (
             variant='h2'
             color={winner.estimatedAnnualSavings > 0 ? 'success.main' : 'error.main'}
             fontWeight={900}
+            gutterBottom={winner.firstYearTotal !== null}
           >
             {format.euro(Math.abs(winner.estimatedAnnualSavings))}
           </Typography>
+          {winner.firstYearTotal !== null && (
+            <Typography variant='subtitle1' color='secondary' fontWeight={800} sx={{ mb: 1 }}>
+              1er año: {format.euro(winner.firstYearTotal)}
+            </Typography>
+          )}
           <Typography variant='caption' color='text.secondary'>
             Frente a proyección de tu tarifa hoy
           </Typography>

--- a/packages/client/src/pages/SupplyDetail/components/chartConfig.ts
+++ b/packages/client/src/pages/SupplyDetail/components/chartConfig.ts
@@ -1,0 +1,24 @@
+import type { Theme } from '@mui/material/styles'
+
+export const getElectricityColors = (theme: Theme) => ({
+  peak: theme.palette.error.main,
+  flat: theme.palette.warning.main,
+  offPeak: theme.palette.success.main,
+})
+
+export const ELECTRICITY_LABELS: Record<'peak' | 'flat' | 'offPeak', string> = {
+  peak: 'Punta',
+  flat: 'Llano',
+  offPeak: 'Valle',
+}
+
+export const CHART_GRID_PROPS = {
+  strokeDasharray: '3 3' as const,
+  vertical: false,
+}
+
+export const CHART_AXIS_PROPS = {
+  tick: { fontSize: 12 },
+  axisLine: false,
+  tickLine: false,
+}

--- a/packages/client/src/pages/SupplyDetail/components/index.ts
+++ b/packages/client/src/pages/SupplyDetail/components/index.ts
@@ -1,2 +1,3 @@
 export { default as SupplyYearStats } from './SupplyYearStats'
 export { default as SupplyConsumptionChart } from './SupplyConsumptionChart'
+export { default as SupplyTrendChart } from './SupplyTrendChart'

--- a/packages/client/src/pages/SupplyDetail/index.tsx
+++ b/packages/client/src/pages/SupplyDetail/index.tsx
@@ -10,7 +10,7 @@ import SupplyForm from '../Supplies/components/SupplyForm'
 import SupplyReadingForm from '../Supplies/components/SupplyReadingForm'
 import SupplyReadingList from '../Supplies/components/SupplyReadingList'
 import RemoveModal from '../Supplies/components/RemoveModal'
-import { SupplyConsumptionChart, SupplyYearStats } from './components'
+import { SupplyConsumptionChart, SupplyYearStats, SupplyTrendChart } from './components'
 import SupplyDetailHeader from './components/SupplyDetailHeader'
 import YearSelector from './components/YearSelector'
 import { useSupplyDetailModals } from './hooks/useSupplyDetailModals'
@@ -99,6 +99,12 @@ const SupplyDetail = () => {
 
       <SupplyYearStats
         readings={filteredReadings}
+        isElectricity={supply.type === 'electricity'}
+        unit={SUPPLY_TYPE_UNITS[supply.type]}
+      />
+
+      <SupplyTrendChart
+        readings={readings}
         isElectricity={supply.type === 'electricity'}
         unit={SUPPLY_TYPE_UNITS[supply.type]}
       />

--- a/packages/client/src/types/supply.ts
+++ b/packages/client/src/types/supply.ts
@@ -1,4 +1,4 @@
-export type SupplyType = 'electricity' | 'water' | 'gas' | 'internet' | 'other'
+export type SupplyType = 'electricity' | 'water' | 'gas' | 'other'
 
 export interface Property {
   _id: string

--- a/packages/models/src/models/supplies.ts
+++ b/packages/models/src/models/supplies.ts
@@ -4,7 +4,6 @@ export const SUPPLY_TYPE = {
   ELECTRICITY: 'electricity',
   WATER: 'water',
   GAS: 'gas',
-  INTERNET: 'internet',
   OTHER: 'other'
 } as const
 


### PR DESCRIPTION
## ¿Qué incluye este PR?
### API ()
- Soporte para **bono social** () en el cálculo de facturas
- Soporte para **descuentos por tarifa** (porcentaje o importe fijo, con duración en meses y flag de nuevos clientes)
- Nuevo campo **`firstYearTotal`**: coste estimado del primer año aplicando el descuento cuando tiene duración definida
- Corrección de la fórmula del **Impuesto Eléctrico**: ahora aplica el mínimo por kWh `MAX(totalKWh × 0.001, base × IE)`
### Hook cliente ()
- Nuevos campos `firstYearTotal` y `discount` expuestos en el tipo `TariffComparison`
### UI cliente
- **`TariffComparisonTable`**: nueva columna *Coste Anual* en la tabla de comparación
- **`TariffRow`**: chip con el descuento activo, celda de coste anual con desglose del primer año, formato simplificado del ahorro (+/-)
- **`WinnerCard`**: chip de descuento junto al nombre de la comercializadora ganadora y línea de coste del primer año cuando aplica
### Tests
- Todos los tests de API y cliente pasan ✅ (468 + 146)
- `Stocks.test.tsx`: eliminadas líneas en blanco al final del fichero