### PR TITLE
fix(client): refrescar suscripciones al aceptar candidato (#658)

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/pages/Subscriptions/index.tsx
+++ b/packages/client/src/pages/Subscriptions/index.tsx
@@ -44,6 +44,15 @@ const Subscriptions = () => {
     mutate(`${SUBSCRIPTIONS}/${subscriptionId}/transactions`)
   }
 
+  const handleAssignCandidate = async (candidateId: string, subscriptionId: string) => {
+    const result = await assign(candidateId, subscriptionId)
+    if (!result.error) {
+      mutate(SUBSCRIPTIONS)
+      mutate(`${SUBSCRIPTIONS}/${subscriptionId}/transactions`)
+    }
+    return result
+  }
+
   return (
     <>
       <HeaderButtons
@@ -53,7 +62,7 @@ const Subscriptions = () => {
 
       <SubscriptionsSummary subscriptions={subscriptions} />
 
-      <CandidatesBanner candidates={candidates} onAssign={assign} onDismiss={dismiss} />
+      <CandidatesBanner candidates={candidates} onAssign={handleAssignCandidate} onDismiss={dismiss} />
 
       {isLoading && <SubscriptionsSkeleton />}
 

--- a/packages/client/src/pages/Subscriptions/index.tsx
+++ b/packages/client/src/pages/Subscriptions/index.tsx
@@ -49,6 +49,7 @@ const Subscriptions = () => {
     if (!result.error) {
       mutate(SUBSCRIPTIONS)
       mutate(`${SUBSCRIPTIONS}/${subscriptionId}/transactions`)
+      mutate(`${SUBSCRIPTIONS}/${subscriptionId}/matching-transactions`)
     }
     return result
   }


### PR DESCRIPTION
Closes #658

### Problema
Al aceptar (asignar) una posible suscripción desde el banner superior de candidatos, la llamada al backend se ejecutaba correctamente pero el frontend no volvía a re-validar los datos guardados en caché por SWR. Por lo tanto, la lista global de suscripciones no reflejaba el cambio.

### Solución
Se envolvió la función `assign` en un nuevo manejador que al finalizar exitosamente, manda la señal `mutate` tanto de `SUBSCRIPTIONS` de manera global como de los movimientos de la suscripción seleccionada.