### PR TITLE
feat(accounts): Traspaso directo entre cuentas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,115 @@
 - **Do not run `npm update`**, `npx npm-check-updates`, or any blind upgrade command. Review each update individually.
 - **Use deterministic installs**: prefer `pnpm install --frozen-lockfile` over `pnpm install` in CI and scripts.
 - **Always communicate in Spanish**: You must answer, explain, and summarize all your work strictily in conversational Spanish.
+- **Code and variables in English**: all variable names, function names, comments, and code must be written in English.
+
+---
+
+## Monorepo structure
+
+```
+packages/
+  models/   @soker90/finper-models  — Mongoose schemas, published to NPM
+  api/      @soker90/finper-api     — Express REST API, port 3008
+  client/   @soker90/finper-client  — React 19 + Vite SPA, port 5173
+```
+
+`api` depends on `models` via `workspace:*`. The API imports from `models/dist/` (compiled output), **not** from source. Without a models build, the API server won't start and imports fail at runtime.
+
+---
+
+## Commands (use `make`, not raw pnpm)
+
+```bash
+# Install
+pnpm install
+
+# Critical: build models BEFORE starting or building the API
+make build-models
+
+# Dev servers (run in separate terminals after build-models)
+make start-api       # http://localhost:3008
+make start-client    # http://localhost:5173
+
+# Build all
+make build-models && make build-api && make build-client
+
+# Tests (all packages in parallel)
+make test
+
+# Tests per package
+make test-models     # Jest + @shelf/jest-mongodb (in-memory MongoDB)
+make test-api        # Jest + @shelf/jest-mongodb
+make test-client     # Vitest (runs with --coverage by default)
+
+# Lint per package
+make lint-models
+make lint-api
+make lint-client
+```
+
+### Run a single test file
+
+```bash
+# API / models (Jest)
+pnpm --filter @soker90/finper-api exec jest src/controllers/account.test.ts
+pnpm --filter @soker90/finper-api exec jest --testNamePattern="should return 200"
+
+# Client (Vitest)
+pnpm --filter @soker90/finper-client exec vitest run src/pages/Accounts/Accounts.test.tsx
+pnpm --filter @soker90/finper-client exec vitest run -t "should render"
+pnpm --filter @soker90/finper-client exec vitest --watch   # watch mode, no coverage
+```
+
+### Typecheck (no dedicated script)
+
+```bash
+pnpm --filter @soker90/finper-client exec tsc --noEmit
+pnpm --filter @soker90/finper-api exec tsc --noEmit
+pnpm --filter @soker90/finper-models exec tsc --noEmit
+```
+
+---
+
+## Toolchain quirks
+
+- **Two test frameworks**: `api` and `models` use Jest (`jest.config.cjs`); `client` uses Vitest configured inside `vite.config.ts` — there is no separate `vitest.config.*`.
+- **In-memory MongoDB** (`@shelf/jest-mongodb`): downloads a MongoDB binary to `~/.cache/mongodb-binaries`. On Ubuntu 22+ requires `libssl1.1` installed manually (CI does this explicitly before tests).
+- **ESLint flat config** (`eslint.config.mjs`) in all three packages. No `.eslintrc`. Uses `neostandard` + `@typescript-eslint`.
+- **Path aliases in client**: defined in both `tsconfig.json` and `vite.config.ts` `resolve.alias`. Adding a new importable directory requires updating both files.
+- **React 19**: use `ref` as a regular prop (no `forwardRef`), `use()` instead of `useContext()`.
+- **PWA**: `vite-plugin-pwa` with `registerType: 'autoUpdate'`. Service worker registers automatically; may interfere in integration test environments.
+- **Node 24** required (`.nvmrc` + `"engines": { "node": ">=24.x" }` in api).
+- **`packageManager` pinned**: root `package.json` declares `pnpm@10.29.3`; `preinstall` script blocks npm/yarn.
+
+---
+
+## Environment variables
+
+Copy `.env.example` to `.env` at repo root:
+
+| Variable | Required | Notes |
+|---|---|---|
+| `DATABASE_NAME` | Yes | |
+| `DATABASE_HOST` | Yes | |
+| `JWT_SECRET` | Yes | |
+| `SALT_ROUNDS` | Yes | |
+| `MONGODB` | No | Overrides host+name if set |
+| `MONGODB_USER` / `MONGODB_PASS` | No | |
+| `TICKET_BOT_URL` / `TICKET_BOT_API_KEY` | No | Tickets module |
+
+Client also needs `packages/client/.env`:
+```dotenv
+VITE_API_HOST=http://localhost:3008/api/
+```
+No fallback is hardcoded; without this variable all API calls fail in development.
+
+---
+
+## Common agent mistakes
+
+- Running `make start-api` or building the API without first running `make build-models`.
+- Adding dependencies with `^` or `~` — always use exact versions.
+- Looking for a `vitest.config.*` in the client — it doesn't exist; Vitest config is in `vite.config.ts`.
+- Running `tsc` expecting a `typecheck` npm script — there isn't one; run `tsc --noEmit` directly.
+- Assuming `make test` is safe to debug a single failing test — it runs all packages in parallel; target the specific package instead.

--- a/packages/api/src/controllers/account.controller.ts
+++ b/packages/api/src/controllers/account.controller.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 
 import { IAccountService } from '../services/account.service'
 import { AccountDocument } from '@soker90/finper-models'
-import { validateAccountCreateParams, validateAccountEditParams, validateAccountExist } from '../validators/account'
+import { validateAccountCreateParams, validateAccountEditParams, validateAccountExist, validateAccountTransferParams } from '../validators/account'
 import '../auth/local-strategy-passport-handler'
 import extractUser from '../helpers/extract-user'
 import { RequestUser } from '../types'
@@ -71,6 +71,25 @@ export class AccountController {
       .then(response => {
         res.send(response)
       }).catch((error) => {
+        next(error)
+      })
+  }
+
+  public async transfer (req: Request, res: Response, next: NextFunction): Promise<void> {
+    Promise.resolve(req.body)
+      .tap(() => this.logger.logInfo(`/transfer - account transfer`))
+      .then(validateAccountTransferParams)
+      .then(extractUser(req))
+      .tap(({ user, sourceId, destinationId }) => Promise.all([
+        validateAccountExist(sourceId as string, user),
+        validateAccountExist(destinationId as string, user)
+      ]))
+      .then(this.accountService.transfer.bind(this.accountService))
+      .tap(() => this.logger.logInfo(`Account transfer has been successfully processed`))
+      .then(() => {
+        res.status(200).send({ message: 'Transfer successful' })
+      })
+      .catch((error) => {
         next(error)
       })
   }

--- a/packages/api/src/controllers/account.controller.ts
+++ b/packages/api/src/controllers/account.controller.ts
@@ -77,7 +77,7 @@ export class AccountController {
 
   public async transfer (req: Request, res: Response, next: NextFunction): Promise<void> {
     Promise.resolve(req.body)
-      .tap(() => this.logger.logInfo(`/transfer - account transfer`))
+      .tap(() => this.logger.logInfo('/transfer - account transfer'))
       .then(validateAccountTransferParams)
       .then(extractUser(req))
       .tap(({ user, sourceId, destinationId }) => Promise.all([
@@ -85,7 +85,7 @@ export class AccountController {
         validateAccountExist(destinationId as string, user)
       ]))
       .then(this.accountService.transfer.bind(this.accountService))
-      .tap(() => this.logger.logInfo(`Account transfer has been successfully processed`))
+      .tap(() => this.logger.logInfo('Account transfer has been successfully processed'))
       .then(() => {
         res.status(200).send({ message: 'Transfer successful' })
       })

--- a/packages/api/src/routes/account.routes.ts
+++ b/packages/api/src/routes/account.routes.ts
@@ -42,5 +42,11 @@ export class AccountRoutes {
       authMiddleware,
       this.accountController.account.bind(this.accountController)
     )
+
+    this.router.post(
+      '/transfer',
+      authMiddleware,
+      this.accountController.transfer.bind(this.accountController)
+    )
   }
 }

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -42,17 +42,30 @@ export default class AccountService implements IAccountService {
   }
 
   public async transfer({ sourceId, destinationId, amount }: { sourceId: string, destinationId: string, amount: number }): Promise<void> {
-    const sourceAccount = await AccountModel.findById(sourceId)
-    const destinationAccount = await AccountModel.findById(destinationId)
+    const session = await AccountModel.startSession()
+    session.startTransaction()
 
-    if (!sourceAccount || !destinationAccount) return
+    try {
+      const sourceAccount = await AccountModel.findById(sourceId).session(session)
+      const destinationAccount = await AccountModel.findById(destinationId).session(session)
 
-    sourceAccount.balance -= amount
-    destinationAccount.balance += amount
+      /* istanbul ignore next — validator validateAccountExist runs before this method via route */
+      if (!sourceAccount || !destinationAccount) {
+        throw Boom.notFound(ERROR_MESSAGE.ACCOUNT.NOT_FOUND).output
+      }
 
-    await Promise.all([
-      sourceAccount.save(),
-      destinationAccount.save()
-    ])
+      sourceAccount.balance -= amount
+      destinationAccount.balance += amount
+
+      await sourceAccount.save({ session })
+      await destinationAccount.save({ session })
+
+      await session.commitTransaction()
+    } catch (error) {
+      await session.abortTransaction()
+      throw error
+    } finally {
+      await session.endSession()
+    }
   }
 }

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -12,14 +12,16 @@ export interface IAccountService {
   getAccounts(user: string): Promise<AccountDocument[]>;
 
   getAccount({ id }: { id: string }): Promise<AccountDocument | null>;
+
+  transfer({ sourceId, destinationId, amount }: { sourceId: string, destinationId: string, amount: number }): Promise<void>;
 }
 
 export default class AccountService implements IAccountService {
-  public async addAccount (account: IAccount): Promise<AccountDocument> {
+  public async addAccount(account: IAccount): Promise<AccountDocument> {
     return AccountModel.create(account)
   }
 
-  public async editAccount ({ id, value }: { id: string, value: IAccount }): Promise<AccountDocument> {
+  public async editAccount({ id, value }: { id: string, value: IAccount }): Promise<AccountDocument> {
     const updated = await AccountModel.findByIdAndUpdate<AccountDocument>(id, value, { returnDocument: 'after' })
     /* istanbul ignore next — validator validateAccountExist runs before this method via route */
     if (!updated) throw Boom.notFound(ERROR_MESSAGE.ACCOUNT.NOT_FOUND).output
@@ -27,15 +29,30 @@ export default class AccountService implements IAccountService {
   }
 
   /* istanbul ignore next — no route endpoint calls deleteAccount */
-  public async deleteAccount (account: AccountDocument): Promise<void> {
+  public async deleteAccount(account: AccountDocument): Promise<void> {
     await AccountModel.updateOne({ _id: account._id }, { $set: { isActive: false } })
   }
 
-  public async getAccounts (user: string): Promise<AccountDocument[]> {
+  public async getAccounts(user: string): Promise<AccountDocument[]> {
     return AccountModel.find({ user, isActive: true }, '_id name bank balance')
   }
 
-  public async getAccount ({ id }: { id: string }): Promise<AccountDocument | null> {
+  public async getAccount({ id }: { id: string }): Promise<AccountDocument | null> {
     return AccountModel.findOne({ _id: id }, '_id name bank balance')
+  }
+
+  public async transfer({ sourceId, destinationId, amount }: { sourceId: string, destinationId: string, amount: number }): Promise<void> {
+    const sourceAccount = await AccountModel.findById(sourceId)
+    const destinationAccount = await AccountModel.findById(destinationId)
+
+    if (!sourceAccount || !destinationAccount) return
+
+    sourceAccount.balance -= amount
+    destinationAccount.balance += amount
+
+    await Promise.all([
+      sourceAccount.save(),
+      destinationAccount.save()
+    ])
   }
 }

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -17,11 +17,11 @@ export interface IAccountService {
 }
 
 export default class AccountService implements IAccountService {
-  public async addAccount(account: IAccount): Promise<AccountDocument> {
+  public async addAccount (account: IAccount): Promise<AccountDocument> {
     return AccountModel.create(account)
   }
 
-  public async editAccount({ id, value }: { id: string, value: IAccount }): Promise<AccountDocument> {
+  public async editAccount ({ id, value }: { id: string, value: IAccount }): Promise<AccountDocument> {
     const updated = await AccountModel.findByIdAndUpdate<AccountDocument>(id, value, { returnDocument: 'after' })
     /* istanbul ignore next — validator validateAccountExist runs before this method via route */
     if (!updated) throw Boom.notFound(ERROR_MESSAGE.ACCOUNT.NOT_FOUND).output
@@ -29,19 +29,19 @@ export default class AccountService implements IAccountService {
   }
 
   /* istanbul ignore next — no route endpoint calls deleteAccount */
-  public async deleteAccount(account: AccountDocument): Promise<void> {
+  public async deleteAccount (account: AccountDocument): Promise<void> {
     await AccountModel.updateOne({ _id: account._id }, { $set: { isActive: false } })
   }
 
-  public async getAccounts(user: string): Promise<AccountDocument[]> {
+  public async getAccounts (user: string): Promise<AccountDocument[]> {
     return AccountModel.find({ user, isActive: true }, '_id name bank balance')
   }
 
-  public async getAccount({ id }: { id: string }): Promise<AccountDocument | null> {
+  public async getAccount ({ id }: { id: string }): Promise<AccountDocument | null> {
     return AccountModel.findOne({ _id: id }, '_id name bank balance')
   }
 
-  public async transfer({ sourceId, destinationId, amount }: { sourceId: string, destinationId: string, amount: number }): Promise<void> {
+  public async transfer ({ sourceId, destinationId, amount }: { sourceId: string, destinationId: string, amount: number }): Promise<void> {
     const session = await AccountModel.startSession()
     session.startTransaction()
 

--- a/packages/api/src/validators/account/index.ts
+++ b/packages/api/src/validators/account/index.ts
@@ -1,3 +1,4 @@
 export * from './validate-account-create-params'
 export * from './validate-account-edit-params'
 export * from './validate-account-exist'
+export * from './validate-account-transfer-params'

--- a/packages/api/src/validators/account/validate-account-transfer-params.ts
+++ b/packages/api/src/validators/account/validate-account-transfer-params.ts
@@ -1,0 +1,18 @@
+import Joi from 'joi'
+import Boom from '@hapi/boom'
+
+export const validateAccountTransferParams = (input: Record<string, string | number>) => {
+  const schema = Joi.object({
+    sourceId: Joi.string().required(),
+    destinationId: Joi.string().required().invalid(Joi.ref('sourceId')),
+    amount: Joi.number().positive().required()
+  })
+
+  const { error, value } = schema.validate(input)
+
+  if (error) {
+    throw Boom.badData(error.message).output
+  }
+
+  return value
+}

--- a/packages/client/src/pages/Accounts/components/ModalTransfer.tsx
+++ b/packages/client/src/pages/Accounts/components/ModalTransfer.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { mutate } from 'swr'
+import { FormHelperText, Grid } from '@mui/material'
+
+import { ModalGrid } from 'components'
+import { InputForm, SelectForm } from 'components/forms'
+import { Account } from 'types'
+import { transferAccountMoney } from 'services/apiService'
+import { ACCOUNTS } from 'constants/api-paths'
+
+interface Props {
+  accounts: Account[]
+  show: boolean
+  onClose: () => void
+}
+
+interface TransferForm {
+  sourceId: string
+  destinationId: string
+  amount: number
+}
+
+const ModalTransfer = ({ accounts, show, onClose }: Props) => {
+  const [error, setError] = useState<string | undefined>(undefined)
+  
+  const { register, handleSubmit, formState: { errors }, watch, reset } = useForm<TransferForm>({
+    defaultValues: {
+      sourceId: '',
+      destinationId: '',
+      amount: 0
+    }
+  })
+
+  const sourceId = watch('sourceId')
+
+  const onSubmit = handleSubmit(async (params) => {
+    if (params.sourceId === params.destinationId) {
+      setError('La cuenta de origen y destino no pueden ser la misma')
+      return
+    }
+
+    const res = await transferAccountMoney(params)
+    
+    if (res.error) {
+      setError(res.error)
+    } else {
+      mutate(ACCOUNTS)
+      reset()
+      onClose()
+    }
+  })
+
+  const activeAccounts = accounts
+  const destinationOptions = activeAccounts.filter(a => a._id !== sourceId)
+
+  return (
+    <ModalGrid
+      show={show}
+      title='Traspaso entre cuentas'
+      onClose={onClose}
+      action={onSubmit}
+    >
+      <SelectForm
+        size={12}
+        id='sourceId' label='Cuenta Origen' placeholder='Cuenta Origen'
+        error={!!errors.sourceId} {...register('sourceId', { required: true })}
+        errorText='Introduce una cuenta válida'
+        options={activeAccounts} optionValue='_id' optionLabel='name'
+        voidOption voidLabel='Selecciona cuenta'
+      />
+      
+      <SelectForm
+        size={12}
+        id='destinationId' label='Cuenta Destino' placeholder='Cuenta Destino'
+        error={!!errors.destinationId} {...register('destinationId', { required: true })}
+        errorText='Introduce una cuenta válida'
+        options={destinationOptions} optionValue='_id' optionLabel='name'
+        voidOption voidLabel='Selecciona cuenta'
+      />
+
+      <InputForm
+        id='amount' label='Cantidad' placeholder='Cantidad a transferir' size={12}
+        error={!!errors.amount} {...register('amount', { required: true, min: 0.01, valueAsNumber: true })}
+        errorText='Introduce una cantidad válida mayor a 0' type='number' inputProps={{ step: 'any', min: 0.01 }}
+      />
+
+      {error && (
+        <Grid size={12}>
+          <FormHelperText error>{error}</FormHelperText>
+        </Grid>
+      )}
+    </ModalGrid>
+  )
+}
+
+export default ModalTransfer

--- a/packages/client/src/pages/Accounts/components/ModalTransfer.tsx
+++ b/packages/client/src/pages/Accounts/components/ModalTransfer.tsx
@@ -23,7 +23,7 @@ interface TransferForm {
 
 const ModalTransfer = ({ accounts, show, onClose }: Props) => {
   const [error, setError] = useState<string | undefined>(undefined)
-  
+
   const { register, handleSubmit, formState: { errors }, watch, reset } = useForm<TransferForm>({
     defaultValues: {
       sourceId: '',
@@ -41,7 +41,7 @@ const ModalTransfer = ({ accounts, show, onClose }: Props) => {
     }
 
     const res = await transferAccountMoney(params)
-    
+
     if (res.error) {
       setError(res.error)
     } else {
@@ -69,7 +69,7 @@ const ModalTransfer = ({ accounts, show, onClose }: Props) => {
         options={activeAccounts} optionValue='_id' optionLabel='name'
         voidOption voidLabel='Selecciona cuenta'
       />
-      
+
       <SelectForm
         size={12}
         id='destinationId' label='Cuenta Destino' placeholder='Cuenta Destino'

--- a/packages/client/src/pages/Accounts/components/index.ts
+++ b/packages/client/src/pages/Accounts/components/index.ts
@@ -1,2 +1,3 @@
 export { default as AccountItem } from './AccountItem'
 export { default as TotalCard } from './TotalCard'
+export { default as ModalTransfer } from './ModalTransfer'

--- a/packages/client/src/pages/Accounts/index.tsx
+++ b/packages/client/src/pages/Accounts/index.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
 import { useAccounts } from 'hooks'
-import { AccountItem, TotalCard } from './components'
-import { PlusOutlined } from '@ant-design/icons'
+import { AccountItem, TotalCard, ModalTransfer } from './components'
+import { PlusOutlined, SwapOutlined } from '@ant-design/icons'
 import { ListContainer } from './components/ListContainer'
 import { HeaderButtons, LoadingList } from 'components'
 
 const Accounts = () => {
   const { accounts, isLoading } = useAccounts()
   const [newAccount, setNewAccount] = useState(false)
+  const [showTransfer, setShowTransfer] = useState(false)
 
   if (isLoading) {
     return <LoadingList />
@@ -19,10 +20,19 @@ const Accounts = () => {
 
   const cancelCreate = () => setNewAccount(false)
 
+  const handleClickTransfer = () => {
+    setShowTransfer(true)
+  }
+
+  const cancelTransfer = () => setShowTransfer(false)
+
   return (
     <>
       <HeaderButtons
-        buttons={[{ Icon: PlusOutlined, title: 'Nueva', onClick: handleClickNew, disabled: newAccount }]}
+        buttons={[
+          { Icon: PlusOutlined, title: 'Nueva', onClick: handleClickNew, disabled: newAccount },
+          { Icon: SwapOutlined, title: 'Traspaso', onClick: handleClickTransfer, disabled: accounts.length < 2 }
+        ]}
         desktopSx={{ marginTop: -7 }}
       />
       <TotalCard value={accounts.reduce((sum, account) => sum + account.balance, 0)} />
@@ -34,6 +44,12 @@ const Accounts = () => {
       </ListContainer>
 
       {!accounts.length && <p>No hay datos</p>}
+
+      <ModalTransfer
+        accounts={accounts}
+        show={showTransfer}
+        onClose={cancelTransfer}
+      />
     </>
   )
 }

--- a/packages/client/src/services/apiService.ts
+++ b/packages/client/src/services/apiService.ts
@@ -23,7 +23,7 @@ export const addAccount = (params: { name?: string, bank?: string, balance?: num
 export const transferAccountMoney = (params: { sourceId: string, destinationId: string, amount: number }): Promise<{
   error?: string | undefined
 }> => {
-  return axios.post(`${ACCOUNTS}/transfer`, params).catch((error: any) => ({ error: extractError(error) }))
+  return axios.post(`${ACCOUNTS}/transfer`, params).then(() => ({})).catch((error: any) => ({ error: extractError(error) }))
 }
 
 export const editCategory = (id: string, params: { name: string, type: string }): Promise<{

--- a/packages/client/src/services/apiService.ts
+++ b/packages/client/src/services/apiService.ts
@@ -20,6 +20,12 @@ export const addAccount = (params: { name?: string, bank?: string, balance?: num
   return axios.post(ACCOUNTS, params).then((data: any) => ({ data: data as Account })).catch((error: any) => ({ error: extractError(error) }))
 }
 
+export const transferAccountMoney = (params: { sourceId: string, destinationId: string, amount: number }): Promise<{
+  error?: string | undefined
+}> => {
+  return axios.post(`${ACCOUNTS}/transfer`, params).catch((error: any) => ({ error: extractError(error) }))
+}
+
 export const editCategory = (id: string, params: { name: string, type: string }): Promise<{
   data?: Category,
   error?: string | undefined


### PR DESCRIPTION
### Descripción
Implementa la funcionalidad de traspaso directo de saldo entre cuentas desde el dashboard, solicitada en #1.

### Cambios
* **API:** Nuevo endpoint `POST /api/accounts/transfer`. Validación con Joi. Actualización directa de saldos sin generar transacciones en el historial.
* **Cliente:** Nuevo modal `ModalTransfer` en la vista de cuentas. Botón de acceso directo en la cabecera. Actualización reactiva de saldos.

### Notas
* El traspaso no crea registros de Ingreso/Gasto en el historial por petición expresa. Solo ajusta los balances.
* Se bloquea el botón si hay menos de 2 cuentas activas.