### PR TITLE
fix(debts): fix table columns, modal validations and date field size

### DIFF
--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -17,7 +17,7 @@ interface Props {
   size?: number
 }
 
-const DateForm = ({ id, label, control, error, errorText, size = 2, ...others }: Props) => (
+const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }: Props) => (
   <Grid size={{ md: size, xs: 12 }}>
     <Stack spacing={1}>
       <InputLabel htmlFor={id}>{label}</InputLabel>

--- a/packages/client/src/pages/Debts/components/DebtEditModal/index.tsx
+++ b/packages/client/src/pages/Debts/components/DebtEditModal/index.tsx
@@ -83,7 +83,7 @@ const DebtEditModal = ({
       <InputForm
         id='concept' label='Concepto' placeholder='Introduce el concepto'
         error={!!errors.concept} {...register('concept', { required: true })}
-        errorText='Introduce un concept válido'
+        errorText='El concepto es obligatorio'
       />
 
     </ModalGrid>

--- a/packages/client/src/pages/Debts/components/DebtEditModal/index.tsx
+++ b/packages/client/src/pages/Debts/components/DebtEditModal/index.tsx
@@ -69,6 +69,7 @@ const DebtEditModal = ({
         placeholder='Introduce una fecha' id='date' label='Fecha'
         error={!!errors.date}
         control={control}
+        size={4}
       />
 
       <InputForm
@@ -81,7 +82,7 @@ const DebtEditModal = ({
 
       <InputForm
         id='concept' label='Concepto' placeholder='Introduce el concepto'
-        error={!!errors.concept} {...register('concept', { required: true, minLength: 6 })}
+        error={!!errors.concept} {...register('concept', { required: true })}
         errorText='Introduce un concept válido'
       />
 

--- a/packages/client/src/pages/Debts/components/DebtTable.tsx
+++ b/packages/client/src/pages/Debts/components/DebtTable.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 const DebtTable = ({ debts, title, fromTitle, onEdit, onRemove, onPay }: Props) => {
   const columns: Column<Debt>[] = [
-    { id: 'from', label: fromTitle },
+    { id: 'from', label: fromTitle, field: 'from' },
     { id: 'date', label: 'Fecha', render: (d) => format.dateShort(d.date) },
     { id: 'amount', label: 'Pendiente', render: (d) => format.euro(d.amount), align: 'right' },
     { id: 'concept', label: 'Concepto', field: 'concept' }

--- a/packages/client/src/pages/Pensions/components/TransactionModal.tsx
+++ b/packages/client/src/pages/Pensions/components/TransactionModal.tsx
@@ -55,10 +55,9 @@ const TransactionModal = ({ onClose, transaction }: Props) => {
         placeholder='Introduce una fecha' id='date' label='Fecha'
         error={!!errors.date}
         control={control}
-        size={4}
       />
       <InputForm
-        id='value' label='Importe Empresa' placeholder='0'
+        id='companyAmount' label='Importe Empresa' placeholder='0'
         error={!!errors.companyAmount} {...register('companyAmount', {
           required: true,
           valueAsNumber: true
@@ -66,7 +65,7 @@ const TransactionModal = ({ onClose, transaction }: Props) => {
         errorText='Introduce un número válido'
       />
       <InputForm
-        id='value' label='Unidades Empresa' placeholder='0'
+        id='companyUnits' label='Unidades Empresa' placeholder='0'
         error={!!errors.companyUnits} {...register('companyUnits', {
           required: true,
           valueAsNumber: true
@@ -74,7 +73,7 @@ const TransactionModal = ({ onClose, transaction }: Props) => {
         errorText='Introduce un número válido'
       />
       <InputForm
-        id='value' label='Importe Empleado' placeholder='0'
+        id='employeeAmount' label='Importe Empleado' placeholder='0'
         error={!!errors.employeeAmount} {...register('employeeAmount', {
           required: true,
           valueAsNumber: true
@@ -82,7 +81,7 @@ const TransactionModal = ({ onClose, transaction }: Props) => {
         errorText='Introduce un número válido'
       />
       <InputForm
-        id='value' label='Unidades Empleado' placeholder='0'
+        id='employeeUnits' label='Unidades Empleado' placeholder='0'
         error={!!errors.employeeUnits} {...register('employeeUnits', {
           required: true,
           valueAsNumber: true

--- a/packages/client/src/pages/Pensions/components/TransactionModal.tsx
+++ b/packages/client/src/pages/Pensions/components/TransactionModal.tsx
@@ -55,6 +55,7 @@ const TransactionModal = ({ onClose, transaction }: Props) => {
         placeholder='Introduce una fecha' id='date' label='Fecha'
         error={!!errors.date}
         control={control}
+        size={4}
       />
       <InputForm
         id='value' label='Importe Empresa' placeholder='0'


### PR DESCRIPTION
## Summary

- Fix missing `field` binding on De/A column in debt table (values were not rendering)
- Remove `minLength` validation on concept field in debt modal
- Increase date field size in debt modal and set a better default size for `DateForm`