### PR TITLE
fix(dashboard): show all accounts with positive balance in pie chart

### DIFF
--- a/packages/client/src/pages/Dashboard/components/budget/AccountsPieChart.tsx
+++ b/packages/client/src/pages/Dashboard/components/budget/AccountsPieChart.tsx
@@ -16,7 +16,6 @@ interface AccountsPieChartProps {
 const AccountsPieChart = ({ accounts, chartColors, isMobile }: AccountsPieChartProps) => {
   const pieData = (accounts || [])
     .filter(a => a.balance > 0)
-    .slice(0, 7)
     .map(a => ({ name: a.name, value: a.balance }))
 
   const pieHeight = isMobile ? 200 : 240


### PR DESCRIPTION
## Summary

- Remove the `.slice(0, 7)` limit in `AccountsPieChart` that was hiding accounts beyond the first 7
- All accounts with balance > 0 are now shown in the distribution chart