### PR TITLE
fix: grant opencode bot write permissions to create PRs from issues

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -25,12 +25,10 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode-go/mimo-v2.5-pro

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -16,18 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
+          persist-credentials: true
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode-go/mimo-v2.5-pro


### PR DESCRIPTION
## Summary

- Changed `contents`, `pull-requests`, and `issues` permissions from `read` to `write` so the bot can push commits and create PRs
- Set `persist-credentials: true` and added explicit `GITHUB_TOKEN` to enable authenticated git operations
- Added `fetch-depth: 0` for full history access needed when creating branches

## Why

The opencode GitHub Action was running successfully but never created PRs because it only had read permissions. This fix allows the bot to fully execute its workflow from issue comments.