### PR TITLE
docs: add layered documentation for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,6 @@ pnpm --filter @soker90/finper-models exec tsc --noEmit
 - **Two test frameworks**: `api` and `models` use Jest (`jest.config.cjs`); `client` uses Vitest configured inside `vite.config.ts` — there is no separate `vitest.config.*`.
 - **In-memory MongoDB** (`@shelf/jest-mongodb`): downloads a MongoDB binary to `~/.cache/mongodb-binaries`. On Ubuntu 22+ requires `libssl1.1` installed manually (CI does this explicitly before tests).
 - **ESLint flat config** (`eslint.config.mjs`) in all three packages. No `.eslintrc`. Uses `neostandard` + `@typescript-eslint`.
-- **Path aliases in client**: defined in both `tsconfig.json` and `vite.config.ts` `resolve.alias`. Adding a new importable directory requires updating both files.
-- **React 19**: use `ref` as a regular prop (no `forwardRef`), `use()` instead of `useContext()`.
 - **PWA**: `vite-plugin-pwa` with `registerType: 'autoUpdate'`. Service worker registers automatically; may interfere in integration test environments.
 - **Node 24** required (`.nvmrc` + `"engines": { "node": ">=24.x" }` in api).
 - **`packageManager` pinned**: root `package.json` declares `pnpm@10.29.3`; `preinstall` script blocks npm/yarn.
@@ -126,3 +124,28 @@ No fallback is hardcoded; without this variable all API calls fail in developmen
 - Looking for a `vitest.config.*` in the client — it doesn't exist; Vitest config is in `vite.config.ts`.
 - Running `tsc` expecting a `typecheck` npm script — there isn't one; run `tsc --noEmit` directly.
 - Assuming `make test` is safe to debug a single failing test — it runs all packages in parallel; target the specific package instead.
+
+---
+
+## Mapa de documentación
+
+Para cualquier tarea no trivial, consultar primero el `AGENTS.md` del paquete afectado: contiene patrones, quirks y checklists detallados.
+
+### Contexto general (leer primero para tareas que cruzan paquetes)
+
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — arquitectura del monorepo, flujo de petición end-to-end, build order, auth, persistencia, tooling, env vars, decisiones técnicas.
+- [`docs/DOMAIN.md`](./docs/DOMAIN.md) — modelo de dominio: entidades, relaciones, enums, convenciones transversales y glosario.
+- [`docs/API-CATALOG.md`](./docs/API-CATALOG.md) — catálogo completo de endpoints REST agrupado por recurso.
+
+### Documentación por paquete
+
+Cada `AGENTS.md` de paquete contiene **solo reglas críticas + checklist + comandos** (~70 líneas). El detalle (patrones, ejemplos, quirks completos) vive en `docs/<paquete>-patterns.md` y se carga bajo demanda.
+
+- [`packages/api/AGENTS.md`](./packages/api/AGENTS.md) → detalle en [`docs/api-patterns.md`](./docs/api-patterns.md).
+- [`packages/client/AGENTS.md`](./packages/client/AGENTS.md) → detalle en [`docs/client-patterns.md`](./docs/client-patterns.md).
+- [`packages/models/AGENTS.md`](./packages/models/AGENTS.md) → detalle en [`docs/models-patterns.md`](./docs/models-patterns.md).
+
+### Documentación técnica de módulos
+
+- [`docs/loan-module.md`](./docs/loan-module.md) — préstamos: amortización francesa, eventos, pagos ordinarios/extraordinarios.
+- [`docs/subscription-module.md`](./docs/subscription-module.md) — suscripciones: candidatos, vinculación de transacciones.

--- a/docs/API-CATALOG.md
+++ b/docs/API-CATALOG.md
@@ -1,0 +1,263 @@
+# API CATALOG
+
+Catálogo de endpoints REST de `@soker90/finper-api`. Base URL: `http://localhost:3008/api/`.
+
+> Para convenciones (auth, errores, validación, controller pattern) ver [`packages/api/AGENTS.md`](../packages/api/AGENTS.md). Este doc es solo el listado.
+
+- **Auth**: todas las rutas requieren `Authorization: Bearer <jwt>` excepto `POST /auth/login`, `POST /auth/register` y `GET /monit/health`.
+- **Header válido**: el middleware `auth.middleware.ts` carga `req.user = username` (string).
+- **Errores**: formato Boom (`{ statusCode, error, message }`) — ver `middlewares/handle-error.ts`.
+- **Orden importa**: `/supplies/properties` y `/supplies/readings` se montan **antes** de `/supplies` en `server.ts:57-59`.
+
+---
+
+## Monit — `/api/monit`
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| GET | `/health` | No | Healthcheck. |
+
+Routes: `monit.routes.ts`.
+
+---
+
+## Auth — `/api/auth`
+
+| Método | Ruta | Auth | Descripción |
+|---|---|---|---|
+| POST | `/login` | No | Devuelve `{ token, user }`. |
+| POST | `/register` | No | Crea usuario + login. |
+| GET | `/me` | Sí | Datos del usuario autenticado. |
+
+Routes: `auth.routes.ts`.
+
+---
+
+## Accounts — `/api/accounts`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear cuenta. |
+| GET | `/` | Listar cuentas del usuario. |
+| GET | `/:id` | Detalle. |
+| PATCH | `/:id` | Editar (parcial). |
+| POST | `/transfer` | Transferencia entre dos cuentas. |
+
+Routes: `account.routes.ts`. Modelo: `Account`.
+
+---
+
+## Categories — `/api/categories`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear categoría (opcional `parent`). |
+| GET | `/` | Listar plano. |
+| GET | `/grouped` | Listar agrupado por padre. |
+| PATCH | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `category.routes.ts`. Modelo: `Category`.
+
+---
+
+## Transactions — `/api/transactions`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear (auto-crea `Store` si no existe). |
+| GET | `/` | Listar con filtros (query params). |
+| PUT | `/:id` | Editar (reemplazo). |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `transaction.routes.ts`. Modelo: `Transaction`. Usa `transactionService` + `storeService`.
+
+---
+
+## Stores — `/api/stores`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/` | Listar. (Sólo lectura; alta implícita vía `Transaction`.) |
+
+Routes: `store.routes.ts`. Modelo: `Store`.
+
+---
+
+## Budgets — `/api/budgets`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/` | Listar (filtros por año/mes vía query). |
+| PATCH | `/:category/:year/:month` | Upsert del importe presupuestado. |
+| POST | `/` | Copiar presupuestos entre periodos. |
+
+Routes: `budget.routes.ts`. Modelo: `Budget`.
+
+---
+
+## Debts — `/api/debts`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear deuda. |
+| GET | `/` | Listar todas. |
+| GET | `/from/:from` | Listar por contraparte (`from`). |
+| PUT | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar. |
+| POST | `/:id/pay` | Registrar pago / cobro (ajusta saldo, puede generar transacción). |
+
+Routes: `debt.routes.ts`. Modelo: `Debt`.
+
+---
+
+## Goals — `/api/goals`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear objetivo. |
+| GET | `/` | Listar. |
+| GET | `/:id` | Detalle. |
+| PUT | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar. |
+| POST | `/:id/fund` | Aportar a objetivo. |
+| POST | `/:id/withdraw` | Retirar de objetivo. |
+
+Routes: `goal.routes.ts`. Modelo: `Goal`.
+
+---
+
+## Loans — `/api/loans`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/` | Listar préstamos. |
+| POST | `/` | Crear préstamo (calcula `monthlyPayment` y `initialEstimatedCost`). |
+| GET | `/:id` | Detalle con pagos y eventos. |
+| PUT | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar (cascada en pagos/eventos según servicio). |
+| POST | `/:id/pay` | Pago ordinario. |
+| POST | `/:id/amortize` | Pago extraordinario (amortización). |
+| POST | `/:id/events` | Añadir evento (cambio tipo/cuota). |
+| PUT | `/:id/payments/:paymentId` | Editar pago. |
+| DELETE | `/:id/payments/:paymentId` | Eliminar pago. |
+
+Routes: `loan.routes.ts`. Modelos: `Loan`, `LoanPayment`, `LoanEvent`. Detalle algorítmico: [`docs/loan-module.md`](./loan-module.md).
+
+---
+
+## Subscriptions — `/api/subscriptions`
+
+> Orden estricto: rutas estáticas (`/candidates*`) antes que dinámicas (`/:id*`) — `subscription.routes.ts:24`.
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear suscripción. |
+| GET | `/` | Listar. |
+| GET | `/candidates` | Listar candidatos (sugerencias tx ↔ sub). |
+| POST | `/candidates/:id/assign` | Confirmar candidato → enlaza transacción. |
+| POST | `/candidates/:id/dismiss` | Descartar candidato. |
+| GET | `/:id/transactions` | Transacciones ya enlazadas a la suscripción. |
+| GET | `/:id/matching-transactions` | Transacciones que matchean (sin enlazar aún). |
+| POST | `/:id/link-transactions` | Enlazar batch de transacciones. |
+| DELETE | `/:id/unlink-transactions/:transactionId` | Desvincular una transacción. |
+| PUT | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `subscription.routes.ts`. Modelos: `Subscription`, `SubscriptionCandidate`. Detalle: [`docs/subscription-module.md`](./subscription-module.md).
+
+---
+
+## Supplies — `/api/supplies`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/` | Listar agrupado por `Property`. |
+| POST | `/` | Crear suministro. |
+| PUT | `/:id` | Editar. |
+| GET | `/:id/tariffs-comparison` | Comparar coste real vs tarifas alternativas. |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `supply.routes.ts`. Modelo: `Supply`. Service extra: `tariffsService`.
+
+### Properties (sub-mount) — `/api/supplies/properties`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear propiedad. |
+| PUT | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `property.routes.ts`. Modelo: `Property`. (No expone GET; el listado llega vía `/api/supplies`.)
+
+### Supply Readings (sub-mount) — `/api/supplies/readings`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/supply/:supplyId` | Lecturas de un suministro. |
+| POST | `/` | Crear lectura. |
+| PUT | `/:id` | Editar. |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `supply-reading.routes.ts`. Modelo: `SupplyReading`.
+
+---
+
+## Stocks — `/api/stocks`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/summary` | Resumen agregado de cartera (calculado en runtime). |
+| GET | `/` | Listar movimientos. |
+| POST | `/` | Crear movimiento (buy/sell/dividend). |
+| DELETE | `/:id` | Eliminar movimiento. |
+
+Routes: `stock.routes.ts`. Modelo: `Stock`. **No** hay PUT.
+
+---
+
+## Pensions — `/api/pensions`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| POST | `/` | Crear snapshot mensual. |
+| GET | `/` | Listar snapshots. |
+| PUT | `/:id` | Editar. |
+
+Routes: `pension.routes.ts`. Modelo: `Pension`. **No** hay DELETE.
+
+---
+
+## Tickets — `/api/tickets`
+
+Integración externa (bot de tickets vía `TICKET_BOT_URL` / `TICKET_BOT_API_KEY`).
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/` | Listar tickets pendientes de revisión. |
+| PATCH | `/:id` | Marcar como revisado / actualizar. |
+| DELETE | `/:id` | Eliminar. |
+
+Routes: `ticket.routes.ts`. Sin modelo Mongoose propio (datos vienen del bot).
+
+---
+
+## Dashboard — `/api/dashboard`
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/stats` | Agregados para el home (saldos, totales mensuales, etc.). |
+
+Routes: `dashboard.routes.ts`. Sin modelo propio; agrega de `Account`, `Transaction`, `Budget`.
+
+---
+
+## Inconsistencias conocidas
+
+Documentadas para no propagar al añadir endpoints nuevos:
+
+- **Verbo de edición**: PATCH (`accounts`, `categories`, `tickets`, `budgets`) vs PUT (`debts`, `goals`, `loans`, `subscriptions`, `transactions`, `pensions`, `properties`, `supplies`, `supply-readings`). **Para código nuevo**: PATCH si la edición es parcial, PUT si reemplaza el documento.
+- **Status creación**: ver `packages/api/AGENTS.md` (algunos POST devuelven 200, otros 201).
+- **Naming sub-recursos**: `/loans/:id/pay` vs `/loans/:id/amortize` (verbos) vs `/goals/:id/fund` y `/subscriptions/:id/link-transactions`. No hay un único estilo.
+- **Sin DELETE**: `Pension` no se puede borrar vía API actual.
+- **Sin PUT**: `Stock` solo permite create/delete (workaround: borrar y recrear).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,263 @@
+# Arquitectura
+
+Visión global de Finper para agentes IA y contribuyentes. Una sola pasada para entender cómo encajan los paquetes, el flujo de petición y el toolchain.
+
+> Para detalles por paquete, ver [`packages/api/AGENTS.md`](../packages/api/AGENTS.md), [`packages/client/AGENTS.md`](../packages/client/AGENTS.md), [`packages/models/AGENTS.md`](../packages/models/AGENTS.md).
+
+---
+
+## 1. Monorepo
+
+```
+finper/
+├── packages/
+│   ├── models/   @soker90/finper-models   — Mongoose schemas (publicable a npm)
+│   ├── api/      @soker90/finper-api      — Express REST API en :3008
+│   └── client/   @soker90/finper-client   — React 19 + Vite SPA en :5173
+├── docs/                                  — documentación técnica
+├── Makefile                               — entrada para todos los comandos
+├── docker-compose.yml                     — MongoDB + API
+└── pnpm-workspace.yaml
+```
+
+### Dependencias entre paquetes
+
+```
+client  ──HTTP──▶  api  ──require──▶  models (dist/)
+                                           │
+                                           ▼
+                                       MongoDB
+```
+
+- `api` depende de `models` vía `workspace:*` y consume el **build compilado** (`packages/models/dist/`), no la fuente. Sin `make build-models`, la API no arranca.
+- `client` no depende de `models`: tiene tipos propios en `src/types/`. La frontera de tipado entre cliente y API es de facto el JSON HTTP.
+- `models` se publica de forma independiente a npm (`finper-bot` u otros consumidores externos pueden usarlo).
+
+---
+
+## 2. Flujo de una petición
+
+```
+Browser (React)
+    │
+    │ axios.get('accounts')
+    │  - baseURL = VITE_API_HOST
+    │  - header `token` desde localStorage[FINPER_TOKEN]
+    ▼
+Express :3008
+    │
+    ▼
+preMiddlewareConfig             — express.json, urlencoded, compression, cors
+    │
+    ▼
+routes/account.routes.ts        — match `/api/accounts` → AccountRoutes
+    │
+    ▼
+middlewares/auth.middleware     — passport.authenticate('jwt')
+    │                             setea req.user = username (string)
+    │                             refresca header `Token` en la respuesta
+    ▼
+controllers/account.controller  — Promise chain con bluebird:
+    │                             tap(log) → then(extractUser)
+    │                             → then(validateXxxParams)
+    │                             → tap(validateXxxExist)
+    │                             → then(service.method)
+    │                             → then(res.send) | catch(next)
+    ▼
+services/account.service        — lógica de negocio
+    │                             throw Boom.<x>(...).output en errores
+    ▼
+@soker90/finper-models          — AccountModel.find(...)
+    │
+    ▼
+MongoDB                         — colección `accounts`
+    │
+    ▲
+    │ (errores → next(error))
+    │
+middlewares/handle-error        — payload Boom.Output → res.status().json()
+                                  errores no-Boom → 500 (badImplementation)
+```
+
+Detalle del Promise chain canónico: `packages/api/AGENTS.md` §2.
+
+---
+
+## 3. Build order
+
+| Orden | Comando | Por qué |
+|---|---|---|
+| 1 | `pnpm install` | Resuelve workspace + lockfile. |
+| 2 | `make build-models` | Genera `packages/models/dist/`. La API y los tests de la API lo importan desde `dist/`. |
+| 3 | `make start-api` | Arranca Express en `:3008`. Requiere `dist/` del paso 2. |
+| 4 | `make start-client` | Arranca Vite en `:5173`. Independiente de los pasos 2 y 3 a nivel de build. |
+
+Para pruebas:
+
+| Comando | Pre-requisito |
+|---|---|
+| `make test-models` | Ninguno (Jest + jest-mongodb). |
+| `make test-api` | `make build-models` previo. Jest + jest-mongodb + supertest. |
+| `make test-client` | Ninguno (Vitest + MSW; no necesita la API real). |
+
+Más detalle del toolchain (Jest vs Vitest, jest-mongodb, ESLint flat config, alias en cliente) en el `AGENTS.md` raíz.
+
+---
+
+## 4. Autenticación
+
+Flujo end-to-end del JWT:
+
+| # | Actor | Acción |
+|---|---|---|
+| 1 | Cliente | `POST /api/auth/login` con `{ username, password }`. |
+| 2 | API | Controlador llama manualmente a `passport.authenticate('local', cb)` (no es middleware). Estrategia local: `UserModel.findOne` + `bcrypt.compareSync`. |
+| 3 | API | Si OK, `authService.getSignedToken(username)` con `config.jwt.secret`, `expiresIn: 1h`. Responde `{ token }`. |
+| 4 | Cliente | Guarda el token en `localStorage[FINPER_TOKEN]`. Interceptor `axios` lo añade en header `token` en cada petición. |
+| 5 | API | Endpoint protegido pasa por `authMiddleware` → `passport.authenticate('jwt', cb)`. Si OK: `req.user = user.username` (string) y refresca header `Token` en la respuesta. |
+| 6 | Cliente | Interceptor `axios` lee header `Token` de la respuesta y actualiza `localStorage`. Implementa refresco continuo mientras el usuario navega. |
+
+Componentes clave:
+
+- `packages/api/src/auth/local-strategy-passport-handler.ts` — registra estrategia `local`.
+- `packages/api/src/auth/jwt-strategy-passport-handler.ts` — registra estrategia `jwt`.
+- `packages/api/src/middlewares/auth.middleware.ts:14-48` — wrapper + refresh.
+- `packages/api/src/helpers/sign-token.ts` — firma JWT.
+- `packages/api/src/services/auth.service.ts` — duplica firma JWT (deuda técnica).
+- `packages/client/src/components/Auth/index.tsx` — inicialización del token al montar.
+- `packages/client/src/utils/axios.ts` — interceptor.
+- `packages/client/src/contexts/AuthContext.tsx` — `hasToken`, `setAccessToken`, `handleLogout`.
+- `packages/client/src/guards/AuthGuard.tsx` / `GuestGuard.tsx` — redirección por rutas.
+
+Endpoints:
+
+| Método | Path | Auth | Propósito |
+|---|---|---|---|
+| `POST` | `/api/auth/register` | público | Crear usuario y devolver token. |
+| `POST` | `/api/auth/login` | público | Login y devolver token. |
+| `GET` | `/api/auth/me` | jwt | Refresca token (responde `204`). |
+
+---
+
+## 5. Persistencia
+
+- **MongoDB** como única base de datos.
+- Conexión gestionada por `@soker90/finper-models` (`packages/models/src/mongoose-connect.ts`).
+- La API la inicia desde `packages/api/src/config/db.ts:19` solo si `NODE_ENV !== 'test'`.
+- En tests (api y models) se usa **MongoDB en memoria** vía `@shelf/jest-mongodb` (`global.__MONGO_URI__`).
+- **Multitenancy**: cada documento (excepto `User`) lleva campo `user: string` con el username. Las queries siempre filtran por `user`.
+- Convenciones de modelo, índices y quirks en [`packages/models/AGENTS.md`](../packages/models/AGENTS.md).
+
+---
+
+## 6. Tooling clave
+
+### Backend
+
+| Pieza | Notas |
+|---|---|
+| Express 5 | Servidor HTTP. |
+| Bluebird | Reemplaza `global.Promise` en `server.ts:30`. Habilita `.tap()` en controllers. |
+| Passport + JWT | Auth (estrategias `local` y `jwt`). |
+| Joi | Validación de params. Validadores en `validators/<dominio>/`. |
+| Boom | Errores HTTP. Lanzar **siempre** `Boom.<x>(...).output`. |
+| Mongoose | Vía `@soker90/finper-models`. |
+| ts-node + ts-jest | Ejecución y test sin build previo de la API. |
+
+### Frontend
+
+| Pieza | Notas |
+|---|---|
+| React 19 | Para código nuevo: `ref` como prop, `use()`. Heredado: `forwardRef`/`useContext`. |
+| Vite 7 | Dev server + build. Plugin PWA con `autoUpdate`. |
+| React Router v7 | `'react-router'` (sin `dom`). `useRoutes` + `lazy`. |
+| MUI v6 | Theme custom fijo en `light`, locale `esES`, dayjs `es`. |
+| SWR | Lectura de datos. Fetcher global axios. Key = constante de `api-paths.ts`. |
+| axios | Cliente HTTP con interceptor de token. |
+| Vitest + happy-dom | Tests con setup global en `vite.config.ts`. |
+| MSW | Mocks de API en tests. Override por test con `server.use`. |
+| @testing-library/react | Render envuelto en `src/test/testUtils.tsx`. |
+
+### Toolchain compartido
+
+| Pieza | Notas |
+|---|---|
+| pnpm 10 (workspaces) | Lockfile obligatorio, `^`/`~` prohibidos. |
+| Make | Punto de entrada para todos los comandos. |
+| ESLint flat config | `neostandard` + `@typescript-eslint`. Sin `.eslintrc`. |
+| `@shelf/jest-mongodb` | MongoDB en memoria para tests. Ubuntu 22+: requiere `libssl1.1`. |
+| Husky + commitlint | Hooks de git. |
+| TypeScript | `strict: true` en api/client; `strictNullChecks: false` en models. |
+| Node 24 | `.nvmrc` y `engines.node ≥24.x`. |
+
+---
+
+## 7. Variables de entorno
+
+`.env` en raíz (consumido por la API):
+
+| Variable | Obligatoria | Notas |
+|---|---|---|
+| `DATABASE_NAME` | Sí | |
+| `DATABASE_HOST` | Sí | |
+| `JWT_SECRET` | Sí | Firma JWT. |
+| `SALT_ROUNDS` | Sí | bcrypt. |
+| `MONGODB` | No | URI completa; tiene prioridad sobre host+name. |
+| `MONGODB_USER` / `MONGODB_PASS` | No | |
+| `TICKET_BOT_URL` / `TICKET_BOT_API_KEY` | No | Integración con `finper-bot`. |
+| `GRAFANA_LOGGER_USER` / `GRAFANA_LOGGER_PASSWORD` | No | Logger externo (no montado actualmente). |
+
+Específicas de Docker Compose (`docker-compose.yml`): `DATABASE_ROOT_USERNAME`, `DATABASE_ROOT_PASSWORD`, `LOKI_USER`, `LOKI_PASSWORD`.
+
+`packages/client/.env` (consumido por Vite):
+
+```dotenv
+VITE_API_HOST=http://localhost:3008/api/
+```
+
+Sin `VITE_API_HOST`, todas las llamadas del cliente fallan en desarrollo (no hay fallback).
+
+---
+
+## 8. Integraciones externas
+
+- **`finper-bot`** ([repo separado](https://github.com/soker90/finper-bot)): servicio de tickets. La API actúa como cliente HTTP usando `TICKET_BOT_URL` + `TICKET_BOT_API_KEY`. Si no se configura, la pantalla de tickets no funciona pero el resto de la app sí.
+- **Proveedor de cotizaciones de stock**: `services/stock-price.provider.ts` consulta una API externa.
+- **Tarifas eléctricas**: `services/tariffs.service.ts` para el módulo de suministros.
+
+---
+
+## 9. Decisiones arquitectónicas
+
+| Decisión | Razón / consecuencia |
+|---|---|
+| Monorepo con `models` separado y publicable | Permite reutilizar los schemas en servicios externos (`finper-bot`). Coste: la API consume `dist/` y requiere build previo. |
+| Cliente con tipos propios (sin importar `models`) | Evita acoplar el bundle del cliente al runtime de Mongoose. Coste: tipos duplicados que pueden divergir. |
+| DI manual en la API (sin contenedor) | Simplicidad. Services como singletons en `services/index.ts`. Coste: `new XxxService()` ad-hoc en algún controller (ver deuda en `packages/api/AGENTS.md`). |
+| Bluebird como `global.Promise` | Habilita `.tap()` para logs y validators de existencia. Coste: dependencia adicional, semántica algo distinta a Promises nativas. |
+| Errores Boom con `.output` (no la instancia) | Estandariza la forma del error en el handler central. Trampa típica si se olvida `.output`. |
+| Validación dentro del Promise chain del controller | Permite mezclar Joi (transforma payload) y validadores DB (sólo lanzan). Coste: validadores no son middlewares Express; no se pueden reutilizar fácilmente fuera del chain. |
+| SWR (lectura) + funciones planas (escritura) en cliente | Cache + revalidación automática para queries; control fino para mutaciones. Patrón consolidado, ver `packages/client/AGENTS.md`. |
+| Theme MUI en español + light fijo | Producto monolingüe y mono-modo. Si se introduce dark mode, hay que migrar `themes/index.tsx`. |
+| MSW para tests del cliente | Tests de página realistas sin mockear `axios`. Coste: necesita `server.use` por test si la respuesta varía. |
+
+---
+
+## 10. Glosario rápido
+
+- **Cuenta** (`Account`): cuenta bancaria del usuario con saldo.
+- **Movimiento** (`Transaction`): ingreso/gasto/transferencia ligado a cuenta y categoría.
+- **Categoría** (`Category`): agrupación de transacciones; tiene tipo (`Income`/`Expense`).
+- **Presupuesto** (`Budget`): tope mensual por categoría (índice único `category+year+month+user`).
+- **Préstamo** (`Loan`) + **LoanPayment** + **LoanEvent**: amortización francesa, pagos y cambios de tipo. Ver [`docs/loan-module.md`](./loan-module.md).
+- **Suscripción** (`Subscription`) + **SubscriptionCandidate**: gastos recurrentes y candidatos detectados. Ver [`docs/subscription-module.md`](./subscription-module.md).
+- **Deuda** (`Debt`): dinero prestado a/desde un tercero.
+- **Meta** (`Goal`): objetivo de ahorro con `targetAmount` y `currentAmount`.
+- **Pensión** (`Pension`): aportaciones a planes de pensiones.
+- **Stock**: compras/ventas de acciones.
+- **Inmueble** (`Property`) + **Suministro** (`Supply`) + **Lectura** (`SupplyReading`): vivienda, contadores y consumo.
+- **Tienda** (`Store`): comercios donde se realizan transacciones.
+- **Ticket**: integración con `finper-bot` (digitalización de recibos).
+- **Usuario** (`User`): credenciales (`username` + `password` con bcrypt).
+
+Ver [`docs/DOMAIN.md`](./DOMAIN.md) para el detalle de campos y relaciones.

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -1,0 +1,111 @@
+# DOMAIN
+
+Modelo de dominio de Finper. Mapa de entidades, relaciones y vocabulario.
+
+> Source of truth: `packages/models/src/models/`. Toda referencia `file:line` apunta a la definición canónica.
+
+---
+
+## Entidades principales
+
+| Modelo | Archivo | Refs FK | Multitenant | Notas |
+|---|---|---|---|---|
+| `User` | `users/index.ts:11` | — | (es el tenant) | `username` único de facto. Hook `pre('save')` encripta password. |
+| `Account` | `accounts.ts:13` | — | `user` | Cuenta bancaria. `balance` con redondeo a 2 decimales (setter). `isActive` para soft-archive. |
+| `Category` | `categories.ts:13` | `parent → Category` | `user` | Jerárquica (1 nivel típico). `type ∈ {income, expense, not_computable}`. |
+| `Transaction` | `transactions.ts:14` | `category`, `account`, `store?`, `subscriptionId?` | `user` | Núcleo del sistema. `date: Number` (timestamp ms). `type` redundante con `category.type`. |
+| `Store` | `stores.ts:11` | — | `user` | Comercio. Collation `es` strength 2 (case+accent insensitive). |
+| `Budget` | `budgets.ts:13` | `category` | `user` | Presupuesto mensual por categoría. Índice único `(category, year, month, user)` (`budgets.ts:23`). |
+| `Debt` | `debts.ts:18` | — | `user` | Deuda informal con tercero. `from` = nombre libre del tercero. `type ∈ {from, to}` (me deben / debo). |
+| `Goal` | `goals.ts:39` | — | `user` | Objetivo de ahorro. `currentAmount` se modifica vía `/fund` y `/withdraw`. Color/icono enum cerrado. |
+| `Loan` | `loans.ts:13` | `account`, `category` | `user` | Préstamo francés. `pendingAmount` se actualiza en cada pago. Detalle: [`loan-module.md`](./loan-module.md). |
+| `LoanPayment` | `loan-payments.ts:18` | `loan` | `user` | Cuota. `type ∈ {ordinary, extraordinary}`. Genera transacción asociada. |
+| `LoanEvent` | `loan-events.ts:13` | `loan` | `user` | Cambio de tipo de interés / cuota mensual con efecto desde `date`. |
+| `Subscription` | `subscriptions.ts:13` | `categoryId`, `accountId` | `user` | Pago recurrente. `cycle` en meses (1..60). `nextPaymentDate` calculado. Detalle: [`subscription-module.md`](./subscription-module.md). |
+| `SubscriptionCandidate` | `subscription-candidates.ts:13` | `transactionId`, `subscriptionIds[]` | `user` | Sugerencia de vinculación tx ↔ subscription. `timestamps.createdAt: true`. |
+| `Stock` | `stocks.ts:21` | — | `user` | Movimiento de cartera. `type ∈ {buy, sell, dividend}`. Sin agregación persistida; el resumen se calcula en `/stocks/summary`. |
+| `Pension` | `pensions.ts:18` | — | `user` | Snapshot mensual del plan de pensiones (aportaciones + valoración). |
+| `Property` | `properties.ts:11` | — | `user` | Inmueble (vivienda). Padre de `Supply`. |
+| `Supply` | `supplies.ts:24` | `propertyId` | `user` | Suministro (luz/agua/gas). Tarifas y potencias contratadas opcionales. |
+| `SupplyReading` | `supply-readings.ts:14` | `supplyId` | `user` | Lectura/factura entre `startDate` y `endDate` (validador inline obliga `endDate > startDate`). |
+
+---
+
+## Relaciones
+
+```
+User (tenant, identificado por username)
+ ├── Account ───────────────────┐
+ ├── Category (self-ref parent) ┤
+ ├── Store ─────────────────────┤
+ ├── Transaction ───────────────┘ (refs account, category, store?, subscriptionId?)
+ │
+ ├── Budget ──→ Category
+ ├── Debt
+ ├── Goal
+ │
+ ├── Loan ──→ Account, Category
+ │    ├── LoanPayment (1:N)
+ │    └── LoanEvent   (1:N)
+ │
+ ├── Subscription ──→ Account, Category
+ │    └── SubscriptionCandidate (1:N por transacción detectada)
+ │
+ ├── Stock
+ ├── Pension
+ │
+ └── Property
+      └── Supply (1:N)
+           └── SupplyReading (1:N)
+```
+
+---
+
+## Convenciones transversales
+
+- **Multitenancy**: todo modelo (excepto `User`) lleva `user: string` (username, no ObjectId). Los services filtran por `{ user }` en cada query.
+- **IDs internos**: `_id` de Mongoose. En la API se serializan como string. El cliente nunca los modifica.
+- **Importes**: `Number` (no Decimal). Cuentas y goals redondean a 2 decimales con setter (`accounts.ts:18`, `goals.ts:48-49`). El resto **no** redondea automáticamente.
+- **Fechas**: predomina `Number` (timestamp ms desde epoch). Excepciones: `goals.deadline: Date` y `subscriptionCandidate.createdAt: Date` (timestamps Mongoose). Para código nuevo: preferir `Number` por consistencia.
+- **Enums**: definidos como `const X = {...} as const` + `type XType = typeof X[keyof typeof X]` (ver `transactions.ts:3-9`). Casing inconsistente entre modelos (UPPERCASE en `STOCK_TYPE`/`SUPPLY_TYPE`/`LOAN_PAYMENT`/`DEBT`, PascalCase en `TRANSACTION`). No bloquea, pero alinear nuevos al patrón UPPERCASE.
+- **Naming FKs**: inconsistente. `transactions.account/category/store` (sin sufijo) vs `subscriptions.accountId/categoryId` y `supplies.propertyId` (con sufijo `Id`). Para código nuevo: `<entidad>Id`.
+- **Índices explícitos**: solo `Budget` (único compuesto), `Loan` (`{user:1}`), `LoanPayment` (`{loan, user, date}`), `LoanEvent` (`{loan, user}`). El resto confía en `_id` y filtros aplicativos. Si una query nueva usa `{user, X}` con frecuencia, añadir índice.
+
+---
+
+## Tipos / enums clave (para validators y UI)
+
+| Constante | Valores | Archivo |
+|---|---|---|
+| `TRANSACTION` | `expense`, `income`, `not_computable` | `transactions.ts:3` |
+| `DEBT` | `from`, `to` | `debts.ts:3` |
+| `LOAN_PAYMENT` | `ordinary`, `extraordinary` | `loan-payments.ts:3` |
+| `STOCK_TYPE` | `buy`, `sell`, `dividend` | `stocks.ts:3` |
+| `SUPPLY_TYPE` | `electricity`, `water`, `gas`, `other` | `supplies.ts:3` |
+| `GOAL_COLORS` | 10 hex literales | `goals.ts:3` |
+| `GOAL_ICONS` | 10 nombres Ant Design | `goals.ts:17` |
+
+`Category.type` reutiliza `TransactionType` (`categories.ts:5`) — un cambio en `TRANSACTION` impacta a `Category` y a `Transaction` simultáneamente.
+
+---
+
+## Glosario
+
+- **Cuota ordinaria** (`ordinary`): pago mensual programado del préstamo. Reduce `pendingAmount` en `principal`.
+- **Cuota extraordinaria** / **amortización** (`extraordinary`): pago anticipado. Recalcula cuota o plazo según evento subsiguiente.
+- **Loan event**: punto en el tiempo a partir del cual cambian `interestRate` y/o `monthlyPayment` (revisión Euribor, refinanciación). Ver `loan-module.md`.
+- **Candidate**: transacción que el detector cree que podría corresponder a una o varias suscripciones. El usuario confirma (`assign`) o descarta (`dismiss`). Ver `subscription-module.md`.
+- **Tariff comparison** (`/api/supplies/:id/tariffs-comparison`): proyecta lecturas existentes contra tarifas alternativas para estimar ahorro.
+- **Pension snapshot**: una entrada `Pension` no es una aportación atómica sino la foto del plan en un momento (`employeeUnits`, `companyUnits`, `value`).
+- **`not_computable`**: tipo de transacción que no entra en cálculos de income/expense (ej. traspasos internos, regularizaciones).
+- **Transfer**: `POST /api/accounts/transfer` mueve saldo entre dos `Account` del mismo usuario. Implementación en `account.controller`/`account.service`.
+
+---
+
+## Cómo añadir una entidad nueva
+
+1. Crear `packages/models/src/models/<entity>.ts` siguiendo el patrón canónico (ver [`packages/models/AGENTS.md`](../packages/models/AGENTS.md#patrón-canónico)).
+2. Registrar en `packages/models/src/index.ts` (3 bloques: imports, document re-exports, `export {}`).
+3. `make build-models` antes de tocar la API.
+4. Crear modelo aguas arriba (service → controller → routes → registro en `server.ts`) siguiendo [`packages/api/AGENTS.md`](../packages/api/AGENTS.md#checklist-añadir-un-recurso-crud).
+5. Si la entidad es navegable desde UI, añadir página/hooks/paths según [`packages/client/AGENTS.md`](../packages/client/AGENTS.md#checklist-añadir-una-página).

--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -1,0 +1,161 @@
+# API patterns
+
+Detalle operativo de `packages/api`. Cargar bajo demanda. Para reglas críticas y checklist, ver [`packages/api/AGENTS.md`](../packages/api/AGENTS.md).
+
+---
+
+## Estructura de `src/`
+
+| Carpeta | Rol |
+|---|---|
+| `auth/` | Estrategias Passport (`local`, `jwt`). Se importan **por side effect** para registrarse. |
+| `config/` | `index.ts` (config central), `db.ts` (wrapper sobre `models.connect`), `inputs.ts` (límites de username/password). |
+| `controllers/` | 18 archivos. Patrón Promise chain con bluebird. |
+| `helpers/` | Funciones puras: `extract-user.ts`, `hash-password.ts`, `sign-token.ts`. |
+| `i18n/` | `ErrorMessages.ts` con `ERROR_MESSAGE` (solo es-ES). |
+| `middlewares/` | `auth.middleware.ts` (jwt + refresh), `handle-error.ts` (handler global). `logger.ts` existe pero **no se monta**. |
+| `routes/` | 18 archivos. Una clase `XxxRoutes` con propiedad `router: Router`. |
+| `scripts/` | `seed-user.ts`. Excluido de cobertura. |
+| `services/` | Una clase por dominio + `dashboard/` modular + `utils/` (helpers de negocio). `index.ts` instancia singletons. |
+| `types/` | `RequestUser`, `CustomError`, `HttpError extends Boom.Output`. |
+| `utils/` | `logger.ts`, `mongoose.ts` (`leanDoc<T>`), `roundNumber.ts`. |
+| `validators/` | Carpeta por dominio con `index.ts` barrel + `validate-<dominio>-<acción>-params.ts` y `validate-<dominio>-exist.ts`. |
+
+---
+
+## Flujo de petición
+
+```
+routes/<X>.routes.ts        → authMiddleware + .bind() del controller
+middlewares/auth.middleware → Passport JWT → req.user = username (string), refresca header Token
+controllers/<X>.controller  → Promise chain bluebird
+services/<X>.service        → lógica + Boom.<x>(...).output en errores
+@soker90/finper-models      → consumido desde dist/
+MongoDB
+```
+
+---
+
+## Patrón canónico de controller
+
+`packages/api/src/controllers/loan.controller.ts:51-58`:
+
+```ts
+public async create (req, res, next) {
+  Promise.resolve(req.body)
+    .tap(({ name }) => this.logger.logInfo(`/loans/create - ${name}`))
+    .then(extractUser(req))                     // .then si transforma payload
+    .then(validateLoanCreateParams)             // Joi: valida y devuelve value
+    .then(this.loanService.createLoan.bind(this.loanService))
+    .then((response) => res.status(201).send(response))
+    .catch(next)
+}
+```
+
+- `.tap()` → no muta el payload (logs, validadores de existencia).
+- `.then()` → muta o consume el payload (validadores Joi, llamadas a service, respuesta).
+- Nunca `try/catch`. Siempre `.catch(next)`.
+
+---
+
+## Routes
+
+- Clase `XxxRoutes` con `router: Router` y `xxxController` privado instanciado inline.
+- `constructor()`: `this.router = Router(); this.routes()`.
+- Cada endpoint: `this.router.<verb>(path, authMiddleware, this.ctrl.method.bind(this.ctrl))`.
+- `authMiddleware` por endpoint. Excepciones: `/auth/login`, `/auth/register`, `/monit/health`.
+- Sin validators como middleware; viven dentro del controller.
+
+---
+
+## Services
+
+- `interface IXxxService` + `default class XxxService implements IXxxService`.
+- Stateless (sin constructor, salvo `auth.service.ts` que recibe `jwtConfig`).
+- Errores: `throw Boom.<x>(ERROR_MESSAGE.<DOMINIO>.<CLAVE>).output`.
+- Queries lean: usar `leanDoc<T>(query)` de `utils/mongoose.ts:5` en vez de cast inline.
+- Lógica compleja → `services/utils/` (`calcLoanProjection.ts`, `calcBudgetByMonths.ts`, `insights.ts`).
+- Registrar singleton en `services/index.ts` y consumirlo desde `routes/`.
+
+---
+
+## Validators
+
+`validators/<dominio>/index.ts` barrel. Dos sub-tipos:
+
+**Params (Joi)** — `validate-<dominio>-<accion>-params.ts`:
+```ts
+export const validateXxxYyyParams = (input) => {
+  const schema = Joi.object({ ... })
+  const { error, value } = schema.validate(input)
+  if (error) throw Boom.badData(error.message).output
+  return value
+}
+```
+`Joi.forbidden()` para campos calculados (ver `validate-loan-create-params.ts:14-15`).
+
+**Existencia (DB)** — `validate-<dominio>-exist.ts`:
+```ts
+if (!Types.ObjectId.isValid(id)) throw Boom.badRequest(...).output
+const exist = await XxxModel.exists({ _id: id, user })
+if (!exist) throw Boom.notFound(...).output
+```
+
+Invocación en el Promise chain:
+- Joi-params con `.then(validateXxx)` (devuelve payload validado).
+- Existencia con `.tap(() => validateXxxExist({ id, user }))` (no devuelve nada).
+
+---
+
+## Auth flow
+
+1. `POST /auth/register` → `validateRegisterInputParams` → `userService.createUser` (con `hash-password`) → JWT.
+2. `POST /auth/login` → `passport.authenticate('local', cb)` invocado **manualmente** dentro del controller (no como middleware) → `authService.getSignedToken(username)` → `{ token }`.
+3. Endpoint protegido: `authMiddleware` invoca `passport.authenticate('jwt', cb)`. Si OK:
+   - `req.user = user.username` (string).
+   - Refresca header `Token` (`auth.middleware.ts:14-18`) — el cliente debe persistirlo.
+4. `GET /auth/me`: solo aplica `authMiddleware` y devuelve `204`. Sirve para refrescar token.
+5. JWT firmado con `config.jwt.secret`, `expiresIn: '1h'`. Helper `helpers/sign-token.ts`.
+
+---
+
+## Errores e i18n
+
+- Mensajes en `i18n/ErrorMessages.ts`, agrupados por dominio: `ERROR_MESSAGE.LOAN.NOT_FOUND`.
+- Handler central `middlewares/handle-error.ts:23-49`, montado en `server.ts:73`.
+- Sin payload Boom → 500 (`badImplementation`) sin filtrar mensaje.
+- No hay locale real, todo en es-ES. Para añadir dominio: nuevo grupo en `ERROR_MESSAGE`.
+
+---
+
+## Tests
+
+- **Carpeta separada** `packages/api/test/` (NO co-localizados).
+- `test/routes/<dominio>.routes.test.ts` — E2E con `supertest` contra `server.app`.
+- `test/services/*.service.test.ts` — unitarios cuando la lógica no se cubre por rutas.
+- `test/utils/*.test.ts` — funciones puras.
+
+Helpers compartidos:
+- `test/test-db.js` — `connect/close/cleanAll` sobre `global.__MONGO_URI__`.
+- `test/insert-data-to-model.ts` — factories (`insertAccount`, `insertLoan`) con faker.
+- `test/request-login.ts` — credenciales + JWT vía `POST /auth/login`.
+
+`@shelf/jest-mongodb` requiere `libssl1.1` en Ubuntu 22+. `NODE_ENV=test` evita `server.start()` y `db.connect()` reales.
+
+```bash
+make test-api
+pnpm --filter @soker90/finper-api exec jest test/routes/loan.routes.test.ts
+pnpm --filter @soker90/finper-api exec jest --testNamePattern="should return 200"
+```
+
+---
+
+## Quirks (no propagar)
+
+- **HTTP en creación**: 200 en account/transaction, 201 en loan. Para nuevo: `201` en POST creación, `204` en DELETE.
+- **Mensajes literales** fuera de `ERROR_MESSAGE` (`validate-loan-exist.ts:6,10`, `account.service.ts:52`). Para nuevo: siempre `ERROR_MESSAGE.<DOMINIO>.<CLAVE>`.
+- **Duplicación firma JWT** entre `auth.service.ts` y `helpers/sign-token.ts`. Reutilizar el helper.
+- **`helmet`** en deps pero **no montado**. Idem `middlewares/logger.ts`.
+- **Estrategias Passport con `require()`**: único sitio sin ES imports (`auth/jwt-strategy-passport-handler.ts:6-10`, `auth/local-strategy-passport-handler.ts:5`). Legado.
+- **Naming FKs inconsistente** (`account` vs `accountId`, …). Mantener consistencia con el modelo afectado; preferir sin sufijo `Id` para nuevos.
+- **`SubscriptionService` con `new` ad-hoc** en `transaction.service.ts` (no usa singleton). Para nuevo: usar singletons de `services/index.ts`.

--- a/docs/client-patterns.md
+++ b/docs/client-patterns.md
@@ -1,0 +1,194 @@
+# Client patterns
+
+Detalle operativo de `packages/client`. Cargar bajo demanda. Para reglas críticas y checklist, ver [`packages/client/AGENTS.md`](../packages/client/AGENTS.md).
+
+---
+
+## Estructura de `src/`
+
+| Carpeta | Rol |
+|---|---|
+| `main.tsx` | Bootstrap React 19 + `BrowserRouter` + `AuthProvider`. |
+| `App.tsx` | Composición de providers. |
+| `components/` | UI compartido (con barrel parcial). |
+| `config/` | Constantes runtime: `API_HOST`, `FINPER_TOKEN`, `drawerWidth`. |
+| `constants/` | `api-paths.ts` (rutas API) y `transactions.ts` (constantes dominio). |
+| `contexts/` | `AuthContext` y `SwrProvider` (sólo dos contexts globales). |
+| `guards/` | `AuthGuard` y `GuestGuard`. |
+| `hooks/` | Hooks SWR globales (compartidos por varias páginas). |
+| `layout/` | `MainLayout` (autenticado) y `AuthLayout` (guest). |
+| `mock/` | Handlers MSW por dominio + `server.ts`. |
+| `pages/` | Una carpeta por sección/ruta. |
+| `routes/` | `useRoutes` + `lazy` + layouts. |
+| `services/` | Sólo `apiService.ts` (mutaciones) y `authService.ts`. **No hay servicio por dominio.** |
+| `test/` | `setup.ts` y `testUtils.tsx` (`render` envuelto en providers). |
+| `themes/` | MUI theme custom (palette, typography, locale `esES`). |
+| `types/` | Tipos por dominio + barrel. |
+| `utils/` | `axios.ts` (interceptor token), `format`, `getColors`, … |
+
+---
+
+## Composición raíz
+
+`main.tsx:10-17` → `App.tsx:11-25`:
+
+```
+<AuthProvider>
+  <BrowserRouter>
+    <App>
+      <ThemeCustomization>           // src/themes/index.tsx
+        <LocalizationProvider>       // dayjs + es
+          <SwrProvider>
+            <Auth>                   // src/components/Auth — inicializa token
+              <Suspense fallback={<Loader/>}>
+                <Routes />
+              </Suspense>
+            </Auth>
+          </SwrProvider>
+        </LocalizationProvider>
+      </ThemeCustomization>
+    </App>
+  </BrowserRouter>
+</AuthProvider>
+```
+
+`utils/axios` se importa por **side effect** desde `App.tsx:7` para registrar el interceptor del header `Token`.
+
+---
+
+## Patrón de página (`pages/<Module>/`)
+
+| Elemento | Convención |
+|---|---|
+| `index.tsx` | Entry con `export default`. Hook SWR → `useState` para modales → `<HeaderButtons>` → render condicional `isLoading`/empty → modales al final. |
+| `components/` | Subcomponentes con barrel `index.ts`. Simples → `Foo.tsx`; complejos → `Foo/index.tsx`. |
+| `hooks/` | Opcional. Hooks SWR/locales propios + barrel. |
+| `utils/` | Opcional. Lógica pura del módulo. |
+| Sub-rutas | Carpetas hermanas: `pages/Loans/LoanDetail/index.tsx`. |
+| Tipos | En `src/types/<dominio>.ts`. **No** crear `types.ts` por página. |
+| Tests | Co-localizados: `Foo.test.tsx` junto a `Foo.tsx`. |
+
+---
+
+## Hooks SWR (lectura)
+
+Plantilla canónica `pages/Loans/hooks/useLoans.ts`:
+
+```ts
+import useSWR from 'swr'
+import { LOANS } from 'constants/api-paths'
+import { Loan } from 'types'
+
+export const useLoans = () => {
+  const { data, error, isLoading } = useSWR<Loan[]>(LOANS)
+  return { loans: data ?? [], isLoading, error: error as Error | undefined }
+}
+```
+
+- Naming `use<Recurso>`. Retorno `{ <recurso>, isLoading, error }` con default `[]` o `null`.
+- **SWR condicional** para detalle: `useSWR(id ? LOAN_DETAIL(id) : null)`.
+- Globales (varios consumidores) → `src/hooks/`. Locales → `src/pages/<X>/hooks/`.
+
+---
+
+## Mutaciones (escritura)
+
+`services/apiService.ts:7-14`:
+
+```ts
+export const editAccount = (id, params): Promise<{ data?: Account, error?: string }> =>
+  axios.patch(`${ACCOUNTS}/${id}`, params)
+    .then((data: any) => ({ data: data as Account }))
+    .catch((error: any) => ({ error: extractError(error) }))
+```
+
+- Naming: `add<Recurso>`, `edit<Recurso>`, `delete<Recurso>` + verbos específicos (`transferAccountMoney`, `payDebt`, `linkSubscriptionTransactions`).
+- Retorno **siempre** `{ data?, error? }` para `if (error) showError(error)`.
+- `extractError` extrae `error.response?.data?.message` con fallback a `error.message`.
+
+### Revalidación tras mutación
+
+`pages/Loans/hooks/useLoanMutate.ts`:
+
+```ts
+import { mutate } from 'swr'
+import { LOANS, LOAN_DETAIL } from 'constants/api-paths'
+
+export const useLoanMutate = (id?: string) => () => {
+  mutate(LOANS)
+  if (id) mutate(LOAN_DETAIL(id))
+}
+```
+
+---
+
+## Routing & guards
+
+- Entry `src/routes/index.ts` con `useRoutes([MainRoutes, LoginRoutes])`.
+- `MainRoutes.tsx` con `lazy(() => import(...))` y `MainLayout` como `element`. Slugs en español (`/cuentas`, `/movimientos`, `/prestamos/:id`).
+- `LoginRoutes.tsx` con `AuthLayout` y `path: 'login'`.
+- `AuthGuard` (`guards/AuthGuard.tsx:4-10`): si `!hasToken()` → `/login`. Envuelve `MainLayout`.
+- `GuestGuard` (`guards/GuestGuard.tsx:4-12`): si `hasToken()` → `/`. Envuelve `AuthLayout`.
+- Redirección raíz: `/` → `/dashboard/default`.
+
+---
+
+## Testing
+
+Setup en `src/test/setup.ts:1-25` (registrado vía bloque `test` de `vite.config.ts`):
+
+- Mock de `localStorage` para happy-dom.
+- MSW: `server.listen({ onUnhandledRequest: 'error' })` en `beforeAll`; `server.resetHandlers()` + clear localStorage en `afterEach`; `server.close()` en `afterAll`.
+
+`testUtils.tsx:12-32` define `AllTheProviders` reproduciendo el árbol de `App` y un `customRender` reexportado como `render`.
+
+### Patrón de test
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../mock/server'
+import { render } from '../../test/testUtils'
+import { SWRConfig } from 'swr'
+
+describe('Goals', () => {
+  it('renders list', async () => {
+    server.use(http.get('*/goals', () => HttpResponse.json([...])))
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <Goals />
+      </SWRConfig>
+    )
+  })
+})
+```
+
+- **Aislar SWR por test** con `<SWRConfig provider={() => new Map()} dedupingInterval={0}>`.
+- **Override handlers** con `server.use(...)`; se resetean automáticamente.
+- Wildcards: `http.get('*/loans', ...)` cubre el `baseURL` de axios.
+
+```bash
+make test-client
+pnpm --filter @soker90/finper-client exec vitest run <archivo>
+pnpm --filter @soker90/finper-client exec vitest -t "render"
+pnpm --filter @soker90/finper-client exec vitest --watch
+```
+
+### Mocks MSW
+
+- `src/mock/handlers/<dominio>.ts` exporta array de handlers.
+- `src/mock/handlers/index.ts` agrega todos.
+- `src/mock/server.ts:1-4`: `setupServer(...handlers)`.
+
+---
+
+## Quirks (no propagar)
+
+- **`forwardRef` legado** en 5 formularios (`components/forms/InputForm.tsx:36`, `SelectForm.tsx:76`, `AutocompleteForm.tsx:64`, `SelectGroupForm/index.tsx:81`, `pages/Accounts/components/AccountEdit/InputForm.tsx:33`). Para nuevo: `ref` como prop normal (React 19).
+- **`useContext` clásico** en `hooks/useAuth.ts`. Para nuevo: preferir `use()` de React 19.
+- **Alias en dos sitios** que pueden desincronizarse: `tsconfig.json:18-32` declara `MuiTable/*` que no está en `vite.config.ts`; `tsconfig` no declara `mock`, `pages`, `routes`, `layout`, `test` (paths relativos). Mantener consistencia al editar.
+- **`config/index.ts` `i18n: 'es'` y `mode: 'light'`** son strings del objeto `config` pero **no se aplican dinámicamente**: theme y textos hardcodeados.
+- **Sin alias `@/`**. No introducirlo sin migración global.
+- **`services/` no es servicios por dominio**: sólo `apiService.ts` y `authService.ts`. No crear `services/account.ts`.
+- **Slugs en español** (`/cuentas`, `/movimientos`). Mantener idioma al añadir.

--- a/docs/models-patterns.md
+++ b/docs/models-patterns.md
@@ -1,0 +1,123 @@
+# Models patterns
+
+Detalle operativo de `packages/models`. Cargar bajo demanda. Para reglas críticas y checklist, ver [`packages/models/AGENTS.md`](../packages/models/AGENTS.md).
+
+---
+
+## Estructura de `src/`
+
+| Fichero / carpeta | Rol |
+|---|---|
+| `index.ts` | Barrel principal: imports → re-exports tipados → `connect` → default export. |
+| `index.d.ts` | Solo `declare module '@soker90/finper-models';`. En `dist/` se sobrescribe por la `.d.ts` real. |
+| `mongoose-connect.ts` | Wrapper sobre `mongoose.connect` con listeners (`connected`, `error`, `disconnected`, `SIGINT`). |
+| `models/<entity>.ts` | Un fichero por modelo (kebab-plural). |
+| `models/users/` | Único modelo con subdirectorio (incluye `hooks/encrypt-password-pre-save.ts`). |
+
+---
+
+## Contrato con la API
+
+- API declara `"@soker90/finper-models": "workspace:*"` y consume `dist/index.js` + `dist/index.d.ts`.
+- `files: ["/dist"]` — solo `dist/` se publica.
+- `index.ts` re-exporta `mongoose` y `Types` para que la API **no importe `mongoose` directo**.
+- Tras cambios: `make build-models`. Si lo olvidas, la API arrancará con el `dist/` viejo o fallará.
+
+---
+
+## Patrón canónico
+
+`accounts.ts` referencia mínima y completa:
+
+```ts
+import { Schema, model, HydratedDocument } from 'mongoose'
+
+export interface IAccount {
+  name: string
+  bank: string
+  balance: number
+  isActive: boolean
+  user: string                                          // multitenancy
+}
+
+export type AccountDocument = HydratedDocument<IAccount>
+
+const accountSchema = new Schema<IAccount>({
+  name: { type: String, required: true },
+  bank: { type: String, required: true },
+  balance: { type: Number, default: 0, set: (n: number) => Math.round(n * 100) / 100 },
+  isActive: { type: Boolean, default: true },
+  user: { type: String, required: true }
+}, { versionKey: false })
+
+export const AccountModel = model<IAccount>('Account', accountSchema)
+```
+
+### Pasos al crear un modelo
+
+| # | Paso | Notas |
+|---|---|---|
+| 1 | `import { Schema, model, HydratedDocument, Types } from 'mongoose'` | `Types` solo si hay refs. |
+| 2 | Constantes enum `as const` + tipo derivado | Solo si hay enums. Ej. `transactions.ts:3-9`. |
+| 3 | `interface I<Entity>` exportada | camelCase, `Types.ObjectId` para refs, `?` para opcionales. |
+| 4 | `type <Entity>Document = HydratedDocument<I<Entity>>` | Exportada. |
+| 5 | `new Schema<I<Entity>>({...}, { versionKey: false })` | `versionKey:false` siempre. |
+| 6 | Refs `{ type: Schema.Types.ObjectId, ref: 'Entity', required: true }` | `'Entity'` singular PascalCase. |
+| 7 | Campo `user: { type: String, required: true }` | Multitenancy obligatoria salvo en `users/`. |
+| 8 | Setter de redondeo a 2 decimales en montos | Solo donde aplica (`accounts.balance`, `goals.targetAmount`). |
+| 9 | `export const <Entity>Model = model<I<Entity>>('Entity', schema)` | Mongoose pluraliza la colección. |
+
+---
+
+## Convenciones
+
+- **Naming de ficheros**: kebab-plural (`accounts.ts`, `loan-payments.ts`). Excepción `users/`.
+- **Naming de exports**:
+  - Interfaces: `I<Entity>` singular PascalCase.
+  - Modelos: `<Entity>Model`.
+  - Documents: `<Entity>Document`.
+  - Nombre Mongoose (1er arg `model()`): singular PascalCase (`'Account'`).
+  - Constantes enum: `SCREAMING_SNAKE_CASE` con `as const`.
+  - Tipo derivado: PascalCase (`TransactionType`).
+- **Multitenancy**: todo modelo (excepto `User`) lleva `user: string`.
+- **Sin virtuals, methods ni statics**. Único hook: `users/hooks/encrypt-password-pre-save.ts:4-7` (bcrypt salt 10).
+- **`versionKey: false`** en todos los schemas.
+- **Re-export desde `index.ts`** en **3 sitios**:
+  1. `import { I<E>, <E>Model } from './models/<entity>'` (líneas 7-24).
+  2. `export type { <E>Document } from './models/<entity>'` (líneas 26-43).
+  3. Bloque final `export { ... }` (líneas 63-121) con `I<E>`, `<E>Model` y enums.
+
+---
+
+## Tests
+
+- Ubicación: `packages/models/test/`.
+- `test/test-db.js` — `connect/close/clear` sobre `global.__MONGO_URI__`.
+- `test/helpers/create-<entity>.ts` — factories con faker que devuelven el documento ya guardado.
+- `test/models/<entity>.test.ts` — un test por modelo cuando existe.
+- **Modelos sin test** (oportunidad, no bloqueante): `loans`, `loan-payments`, `loan-events`, `goals`, `subscriptions`, `subscription-candidates`, `stocks`.
+
+```bash
+make test-models
+pnpm --filter @soker90/finper-models exec jest test/models/account.test.ts
+make lint-models
+pnpm --filter @soker90/finper-models exec tsc --noEmit
+```
+
+---
+
+## Quirks (no propagar)
+
+- **Fechas mezcladas**: la mayoría usa `Number` (timestamp). Solo `goals.deadline` y `subscription-candidates.createdAt` usan `Date`. Para nuevo: preferir `Number`.
+- **Casing de claves enum inconsistente**: `TRANSACTION.Expense`, `STOCK_TYPE.Buy` (PascalCase) vs `LOAN_PAYMENT.ORDINARY`, `SUPPLY_TYPE.ELECTRICITY`, `DEBT.FROM` (SCREAMING). Para nuevo: SCREAMING.
+- **Naming de FKs inconsistente**: `account` vs `accountId`. Para nuevo: preferir sin sufijo `Id`.
+- **`strictNullChecks: false`** (`tsconfig.json:16`). Tests asumen `findOne()` no null sin chequear. No habilitar sin migración global.
+- **`bluebird` en deps** pero no se importa. Posible eliminación.
+- **Solo 4 modelos con índices explícitos** pese a que todos filtran por `user`:
+  - `budgets.ts:21` — `{ category, year, month, user }` `unique: true`.
+  - `loans.ts:31` — `{ user: 1 }`.
+  - `loan-payments.ts:36` — `{ loan, user, date }`.
+  - `loan-events.ts:21` — `{ loan, user }`.
+  Para nuevo modelo con queries frecuentes por `user`: añadir índice.
+- **Versiones con `^`** en `package.json` (mongoose, bcrypt, …). Contradice regla raíz; no añadir nuevas con `^` o `~`.
+- **`tsconfig-build.json`** existe pero `build` invoca `tsc` plano (usa `tsconfig.json`). Probablemente obsoleto.

--- a/packages/api/AGENTS.md
+++ b/packages/api/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS — `@soker90/finper-api`
+
+> Patrones detallados (estructura, controllers, services, validators, auth flow, tests, ejemplos): [`docs/api-patterns.md`](../../docs/api-patterns.md).
+> Catálogo de endpoints: [`docs/API-CATALOG.md`](../../docs/API-CATALOG.md).
+
+**Antes de tocar la API**, si has modificado `packages/models`, ejecuta `make build-models`. La API consume `packages/models/dist/`, no `src/`.
+
+---
+
+## Reglas críticas (rompen cosas si las ignoras)
+
+1. **Bluebird global**: `server.ts:30` reemplaza `global.Promise`. Por eso `.tap()` está disponible sin importar bluebird.
+2. **`req.user` es `string`** (el username), no un objeto. Asignado por `auth.middleware.ts:44`. Patrón `req.user as string` por todo el código.
+3. **Errores con `.output`**: `throw Boom.<x>(message).output`, **no** `throw Boom.<x>(message)`. El handler espera `Boom.Output` (`handle-error.ts:31`).
+4. **Imports Passport por side effect** (`auth.middleware.ts:7`). Olvidarlo → *Unknown authentication strategy*.
+5. **`.bind(controller)` obligatorio en routes**. Sin él, `this` falla en runtime.
+6. **Validators NO son middleware Express**. Se invocan en el Promise chain del controller:
+   - Joi-params con `.then(validateXxx)` (devuelve payload validado).
+   - Existencia con `.tap(() => validateXxxExist({ id, user }))` (no devuelve nada).
+7. **DI manual sin contenedor**: singletons en `services/index.ts`. Cada `routes/*.routes.ts` instancia su controller inline. No `new XxxService()` ad-hoc dentro de otros services.
+8. **Order matters al montar rutas** (`server.ts:57-59`): `/api/supplies/properties` y `/api/supplies/readings` van **antes** de `/api/supplies` para evitar shadowing.
+9. **`models.connect` es no-op si `NODE_ENV=test`** (`config/db.ts:19`); los tests conectan vía `test/test-db.js`.
+10. **`/* istanbul ignore next — <razón> */`** con razón explícita. No quitarlas al refactorizar.
+
+---
+
+## Checklist: añadir un recurso CRUD (`Foo`)
+
+1. Modelo en `packages/models/src/models/foos.ts` y registrar en `packages/models/src/index.ts` (ver [`packages/models/AGENTS.md`](../models/AGENTS.md)).
+2. `make build-models`.
+3. `validators/foo/`: `validate-foo-create-params.ts`, `validate-foo-edit-params.ts`, `validate-foo-exist.ts`, `index.ts` barrel.
+4. `services/foo.service.ts` con `interface IFooService` + `default class FooService`.
+5. Singleton en `services/index.ts`: `export const fooService = new FooService()`.
+6. `controllers/foo.controller.ts` con clase `FooController` y DI por constructor.
+7. `routes/foo.routes.ts` con clase `FooRoutes`, controller inline, `.bind()` en cada handler.
+8. Registrar en `server.ts`: `this.app.use('/api/foos', new FooRoutes().router)`.
+9. Mensajes en `i18n/ErrorMessages.ts`: nuevo grupo `FOO`.
+10. Tests en `packages/api/test/routes/foo.routes.test.ts` (mínimo: list, get, create, edit, delete, 401/404/422). Factory `insertFoo` si se reutiliza.
+11. Verificar: tests, lint y typecheck del paquete (ver comandos en raíz).
+
+---
+
+## Comandos específicos
+
+> Comandos genéricos (build, test, lint, typecheck) en el [`AGENTS.md` raíz](../../AGENTS.md#commands-use-make-not-raw-pnpm).
+
+```bash
+make seed-user USERNAME=miusuario PASSWORD=mipassword
+pnpm --filter @soker90/finper-api exec jest test/routes/loan.routes.test.ts
+pnpm --filter @soker90/finper-api exec jest --testNamePattern="should return 200"
+```

--- a/packages/client/AGENTS.md
+++ b/packages/client/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS — `@soker90/finper-client`
+
+> Patrones detallados (estructura, providers, hooks SWR, mutaciones, routing, testing, MSW, ejemplos): [`docs/client-patterns.md`](../../docs/client-patterns.md).
+
+---
+
+## Reglas críticas (rompen cosas si las ignoras)
+
+1. **Lectura ⇒ hooks SWR** (`src/hooks/` o `src/pages/<X>/hooks/`). **Escritura ⇒ funciones planas** en `services/apiService.ts` con retorno `{ data?, error? }`. No mezclar.
+2. **Key SWR = constante de `constants/api-paths.ts`**. Nunca hardcodear URLs en hooks.
+3. **Fetcher global** en `SwrProvider.tsx:10`. Hooks llaman `useSWR(KEY)` sin pasar fetcher.
+4. **Alias TS sin prefijo `@`**. Imports como `import { Loader } from 'components'`. Definidos en **dos sitios** que deben mantenerse sincronizados:
+   - `packages/client/tsconfig.json:18-32` (`baseUrl: "./src"` + `paths`).
+   - `packages/client/vite.config.ts:14-28` (`resolve.alias`).
+   Al añadir carpeta raíz importable: actualizar **ambos**.
+5. **React Router v7** importado desde `'react-router'` (no `react-router-dom`).
+6. **Token JWT** en `localStorage[FINPER_TOKEN]` (`config/index.ts`). Interceptor en `utils/axios.ts:7-14` lo inyecta y refresca al recibir el header `Token`.
+7. **React 19**: para código nuevo, `ref` como prop normal (sin `forwardRef`) y `use()` en vez de `useContext()`. 5 formularios y `useAuth` siguen el patrón legado — no propagar.
+8. **Tests co-localizados** (a diferencia de la API). Usar siempre el `render` de `src/test/testUtils.tsx`, nunca el de `@testing-library/react` directamente.
+9. **Aislar SWR por test** con `<SWRConfig provider={() => new Map()} dedupingInterval={0}>` para evitar cache compartido entre casos.
+10. **`services/` ≠ servicios por dominio**: sólo `apiService.ts` y `authService.ts`. No crear `services/account.ts`.
+
+---
+
+## Checklist: añadir página/módulo (`Foo`)
+
+1. `src/constants/api-paths.ts`: `export const FOOS = 'foos'` y `export const FOO_DETAIL = (id) => 'foos/${id}'`.
+2. Tipos en `src/types/foo.ts` y reexport en `src/types/index.ts`.
+3. Hook SWR de lectura: global → `src/hooks/useFoos.ts`; local → `src/pages/Foos/hooks/useFoos.ts` + barrel.
+4. Mutaciones en `src/services/apiService.ts` (`addFoo`, `editFoo`, `deleteFoo`) con `{ data?, error? }`.
+5. Hook de revalidación: `src/pages/Foos/hooks/useFooMutate.ts` (si hay detalle por id).
+6. Página: `src/pages/Foos/index.tsx` con `export default`, subcomponentes en `components/` (con barrel).
+7. Lazy import + ruta en `src/routes/MainRoutes.tsx`.
+8. Mock: `src/mock/handlers/foos.ts` + entrada en `src/mock/handlers/index.ts`.
+9. Tests co-localizados: `src/pages/Foos/Foos.test.tsx` (render, empty, error, mutación).
+10. Si añades **carpeta raíz importable nueva**: sincronizar `tsconfig.json` y `vite.config.ts`.
+11. Verificar: tests, lint y typecheck del paquete (ver comandos en raíz).
+
+---
+
+## Comandos específicos
+
+> Comandos genéricos (build, test, lint, typecheck) en el [`AGENTS.md` raíz](../../AGENTS.md#commands-use-make-not-raw-pnpm).
+
+```bash
+pnpm --filter @soker90/finper-client exec vitest run <archivo>
+pnpm --filter @soker90/finper-client exec vitest -t "render"
+pnpm --filter @soker90/finper-client exec vitest --watch         # sin cobertura
+```

--- a/packages/models/AGENTS.md
+++ b/packages/models/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS — `@soker90/finper-models`
+
+> Patrones detallados (estructura, plantilla canónica, convenciones, tests, ejemplos): [`docs/models-patterns.md`](../../docs/models-patterns.md).
+
+**Crítico**: la API consume este paquete desde `dist/`, no desde `src/`. Cualquier cambio aquí requiere `make build-models` antes de arrancar o testear la API.
+
+---
+
+## Reglas críticas (rompen cosas si las ignoras)
+
+1. **API consume `dist/`**. Olvidar `make build-models` → la API usa el `dist/` viejo o falla al importar.
+2. **Multitenancy**: todo modelo (excepto `User`) lleva `user: string`. Los services filtran siempre por `{ user }`.
+3. **`versionKey: false`** en todos los schemas. Nunca persistir `__v`.
+4. **Sin virtuals, methods ni statics**. Único hook: `users/hooks/encrypt-password-pre-save.ts:4-7`.
+5. **No importar `mongoose` directo desde la API**. `index.ts` re-exporta `mongoose` y `Types`; usar esos.
+6. **Re-export en `index.ts` requiere actualizar 3 sitios** al añadir un modelo: imports (líneas 7-24), document re-exports (26-43), bloque final `export { ... }` (63-121).
+7. **`strictNullChecks: false`** (`tsconfig.json:16`). No habilitar sin migración global; los tests asumen que `findOne()` no es null.
+
+---
+
+## Convenciones rápidas
+
+- **Naming de ficheros**: kebab-plural (`accounts.ts`, `loan-payments.ts`). Excepción `users/`.
+- **Exports**: `I<Entity>`, `<Entity>Model`, `<Entity>Document`. Nombre Mongoose: singular PascalCase.
+- **Enums**: `SCREAMING_SNAKE_CASE` `as const` + `<Entity>Type` PascalCase derivado.
+- **Refs**: `{ type: Schema.Types.ObjectId, ref: 'Entity', required: true }`.
+- **Para código nuevo**: fechas como `Number` (timestamp), enums en SCREAMING, FKs sin sufijo `Id`. Ver quirks en [`docs/models-patterns.md`](../../docs/models-patterns.md#quirks-no-propagar).
+
+---
+
+## Checklist: añadir un modelo (`Foo`)
+
+1. Crear `packages/models/src/models/foos.ts` siguiendo el patrón canónico ([`docs/models-patterns.md`](../../docs/models-patterns.md#patrón-canónico)).
+2. Si tiene enum: `FOO_TYPE` `as const` + `FooType` derivado.
+3. Actualizar `packages/models/src/index.ts` en **3 sitios**: import, `export type { FooDocument }`, bloque final `export { ... }`.
+4. Considerar índice `{ user: 1, ... }` si las queries van a ser frecuentes (solo 4 modelos lo tienen hoy).
+5. Factory `packages/models/test/helpers/create-foo.ts`.
+6. Test `packages/models/test/models/foo.test.ts` (persistir + recuperar).
+7. Verificar: build, tests, lint y typecheck del paquete (ver comandos en raíz). **`make build-models` antes de seguir.**
+8. Solo después: importar `FooModel` desde `@soker90/finper-models` en la API.
+
+---
+
+## Comandos específicos
+
+> Comandos genéricos (build, test, lint, typecheck) en el [`AGENTS.md` raíz](../../AGENTS.md#commands-use-make-not-raw-pnpm). Recordatorio: **`make build-models` es obligatorio antes de arrancar o testear la API**.
+
+```bash
+pnpm --filter @soker90/finper-models exec jest test/models/account.test.ts
+```


### PR DESCRIPTION
## Summary

- Add 3 root-level docs: `ARCHITECTURE.md` (monorepo architecture), `DOMAIN.md` (18 entities, relationships, glossary), `API-CATALOG.md` (complete REST endpoint catalog)
- Add 3 per-package `AGENTS.md` (~50 lines each) with critical rules, checklists, and commands — deduplicated from root
- Add 3 `docs/*-patterns.md` files with detailed patterns, examples, and quirks — loaded on demand
- Update root `AGENTS.md` with documentation map linking all files
- Remove duplicated client-specific rules (aliases, React 19) from root, now only in `packages/client/AGENTS.md`

## Design

Documentation is organized in layers to minimize context consumption:

| Layer | Location | Lines | Purpose |
|---|---|---|---|
| Root rules | `AGENTS.md` | ~150 | pnpm, lockfile, monorepo structure, global commands, toolchain quirks |
| Package rules | `packages/*/AGENTS.md` | ~50 each | Critical rules that break things if ignored, per-package checklists |
| Package patterns | `docs/*-patterns.md` | 120-194 each | Detailed patterns, examples, quirks — loaded on demand |
| Context docs | `docs/{ARCHITECTURE,DOMAIN,API-CATALOG}.md` | 110-263 each | Architecture, domain model, endpoint catalog |
| Module docs | `docs/{loan,subscription}-module.md` | existing | Deep module-specific documentation |

**Total initial context for an agent**: ~200 lines (root + one package AGENTS.md), vs ~720 lines before.

## Commits

1. `docs: add root-level architecture, domain, and API catalog`
2. `docs: add per-package AGENTS.md with critical rules and checklists`
3. `docs: move package patterns to docs/ for on-demand loading`
4. `docs: add documentation map to root AGENTS.md`