### PR TITLE
feat: refine dashboard financial score

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - **Always communicate in Spanish**: You must answer, explain, and summarize all your work strictily in conversational Spanish.
 - **Code and variables in English**: all variable names, function names, comments, and code must be written in English.
 - **Descriptive variable names**: never use single letters (like `a`, `b`, `x`, `i`, `j`) as variable names except for well-known loop counters (`i`, `j`, `k`). Always use descriptive, self-explanatory names.
+- **Object params for functions with more than two parameters**: when a function requires more than two parameters, pass them as a single named object instead of positional arguments. This improves readability and avoids argument-order mistakes.
 
 ---
 

--- a/packages/api/src/services/dashboard/dashboard.service.ts
+++ b/packages/api/src/services/dashboard/dashboard.service.ts
@@ -1,7 +1,7 @@
 import { AccountModel, DebtModel, LoanModel, PensionModel, TransactionModel, TRANSACTION, type IPension } from '@soker90/finper-models'
 import { roundNumber } from '../../utils/roundNumber'
 import { generateInsights } from '../utils/insights'
-import { computeHealthScore, computeBudgetAdherence } from './health-score'
+import { computeHealthScore, computeBudgetAdherence, computeHistoricalSavingsRate } from './health-score'
 import { computeFilteredAvgMonthlyExpense, type MonthTransactionsRow } from './cash-runway'
 import {
   aggregateCurrentMonthByCategory,
@@ -359,6 +359,15 @@ export default class DashboardService implements IDashboardService {
       ? Math.round(((monthlyIncome - monthlyExpenses) / monthlyIncome) * 10000) / 100
       : 0
 
+    // Historical savings rate: avg of last 3 completed months to avoid
+    // distortion caused by the in-progress current month (partial expenses).
+    const historicalSavingsRate = computeHistoricalSavingsRate(
+      last6MonthsAgg,
+      currentMonth,
+      currentYear,
+      savingsRate
+    )
+
     // Expense velocity
     const daysInCurrentMonth = new Date(currentYear, currentMonth + 1, 0).getDate()
     const daysInPreviousMonth = new Date(previousYear, previousMonth + 1, 0).getDate()
@@ -436,7 +445,7 @@ export default class DashboardService implements IDashboardService {
 
     // Health Score
     const healthScore = computeHealthScore(
-      savingsRate,
+      historicalSavingsRate,
       totalDebts + totalLoansPending,
       totalBalance,
       budgetAdherencePct,

--- a/packages/api/src/services/dashboard/dashboard.service.ts
+++ b/packages/api/src/services/dashboard/dashboard.service.ts
@@ -361,12 +361,12 @@ export default class DashboardService implements IDashboardService {
 
     // Historical savings rate: avg of last 3 completed months to avoid
     // distortion caused by the in-progress current month (partial expenses).
-    const historicalSavingsRate = computeHistoricalSavingsRate(
-      last6MonthsAgg,
-      currentMonth,
+    const historicalSavingsRate = computeHistoricalSavingsRate({
+      last6Months: last6MonthsAgg,
+      currentMonthIndex: currentMonth,
       currentYear,
-      savingsRate
-    )
+      fallback: savingsRate
+    })
 
     // Expense velocity
     const daysInCurrentMonth = new Date(currentYear, currentMonth + 1, 0).getDate()

--- a/packages/api/src/services/dashboard/health-score.ts
+++ b/packages/api/src/services/dashboard/health-score.ts
@@ -1,13 +1,60 @@
-import type { HealthScore } from './dashboard.types'
+import type { HealthScore, MonthlyData } from './dashboard.types'
+
+/**
+ * Computes the savings score using a progressive scale:
+ * - 0–5%:   0–30 pts  (danger zone)
+ * - 5–15%:  30–70 pts (healthy zone)
+ * - 15–30%: 70–100 pts (excellent zone)
+ * - >30%:   100 pts
+ * - <=0%:   0 pts (no savings or negative rate)
+ */
+export const computeSavingsScore = (rate: number): number => {
+  if (rate <= 0) return 0
+  if (rate < 5) return Math.round((rate / 5) * 30)
+  if (rate < 15) return Math.round(30 + ((rate - 5) / 10) * 40)
+  if (rate < 30) return Math.round(70 + ((rate - 15) / 15) * 30)
+  return 100
+}
+
+/**
+ * Computes the historical savings rate as the arithmetic mean of the savings rate
+ * of the last completed months (up to 3). Months with no income are excluded.
+ * Falls back to the current month's savings rate when no historical data is available.
+ */
+export const computeHistoricalSavingsRate = (
+  last6Months: MonthlyData[],
+  currentMonthIndex: number,  // 0-indexed month of "now" (0 = Jan, 11 = Dec)
+  currentYear: number,
+  fallback: number
+): number => {
+  const completedMonths = last6Months.filter(monthData => {
+    // Exclude the current in-progress month
+    const isCurrentMonth = monthData.month === currentMonthIndex + 1 && monthData.year === currentYear
+    return !isCurrentMonth && monthData.income > 0
+  })
+
+  const recentMonths = completedMonths.slice(-3)
+  if (recentMonths.length === 0) return fallback
+
+  const totalRate = recentMonths.reduce((sum, monthData) => {
+    const monthRate = ((monthData.income - monthData.expenses) / monthData.income) * 100
+    return sum + monthRate
+  }, 0)
+
+  return Math.round((totalRate / recentMonths.length) * 100) / 100
+}
 
 /**
  * Computes the financial health score from 5 weighted sub-scores.
  *
  * Weights: savingsRate 25%, debtRatio 20%, budgetAdherence 20%,
  *          cashRunway 20%, pensionReturn 15%.
+ *
+ * savingsRate should be the historical rate (avg of last 3 completed months)
+ * to avoid distortion from the in-progress current month.
  */
 export const computeHealthScore = (
-  savingsRate: number,        // e.g. 15 → 15%
+  savingsRate: number,        // historical avg savings rate (last 3 completed months)
   totalDebts: number,         // absolute monetary value
   totalBalance: number,       // absolute monetary value
   budgetAdherencePct: number, // 0–100
@@ -17,7 +64,7 @@ export const computeHealthScore = (
   const clamp = (v: number, min: number, max: number): number =>
     Math.max(min, Math.min(max, v))
 
-  const savingsScore = Math.round(clamp(savingsRate / 20, 0, 1) * 100)
+  const savingsScore = computeSavingsScore(savingsRate)
   const debtScore = Math.round(Math.max(0, 1 - (totalBalance > 0 ? totalDebts / totalBalance : 1)) * 100)
   const budgetScore = Math.round(Math.min(budgetAdherencePct, 100))
   const runwayScore = Math.round(Math.min(cashRunwayMonths / 6, 1) * 100)

--- a/packages/api/src/services/dashboard/health-score.ts
+++ b/packages/api/src/services/dashboard/health-score.ts
@@ -9,7 +9,7 @@ import type { HealthScore, MonthlyData } from './dashboard.types'
  * - <=0%:   0 pts (no savings or negative rate)
  */
 export const computeSavingsScore = (rate: number): number => {
-  if (rate <= 0) return 0
+  if (rate <= 0 || Number.isNaN(rate)) return 0
   if (rate < 5) return Math.round((rate / 5) * 30)
   if (rate < 15) return Math.round(30 + ((rate - 5) / 10) * 40)
   if (rate < 30) return Math.round(70 + ((rate - 15) / 15) * 30)
@@ -28,9 +28,10 @@ export const computeHistoricalSavingsRate = (
   fallback: number
 ): number => {
   const completedMonths = last6Months.filter(monthData => {
-    // Exclude the current in-progress month
-    const isCurrentMonth = monthData.month === currentMonthIndex + 1 && monthData.year === currentYear
-    return !isCurrentMonth && monthData.income > 0
+    // Only include strictly past months to avoid distortion from future-dated transactions
+    const isPastMonth = monthData.year < currentYear ||
+      (monthData.year === currentYear && monthData.month < currentMonthIndex + 1)
+    return isPastMonth && monthData.income > 0
   })
 
   const recentMonths = completedMonths.slice(-3)

--- a/packages/api/src/services/dashboard/health-score.ts
+++ b/packages/api/src/services/dashboard/health-score.ts
@@ -1,3 +1,4 @@
+import { roundNumber } from '../../utils/roundNumber'
 import type { HealthScore, MonthlyData } from './dashboard.types'
 
 /**
@@ -49,7 +50,7 @@ export const computeHistoricalSavingsRate = ({
     return sum + monthRate
   }, 0)
 
-  return Math.round((totalRate / recentMonths.length) * 100) / 100
+  return roundNumber(totalRate / recentMonths.length)
 }
 
 /**

--- a/packages/api/src/services/dashboard/health-score.ts
+++ b/packages/api/src/services/dashboard/health-score.ts
@@ -16,17 +16,24 @@ export const computeSavingsScore = (rate: number): number => {
   return 100
 }
 
+interface ComputeHistoricalSavingsRateParams {
+  last6Months: MonthlyData[]
+  currentMonthIndex: number  // 0-indexed month of "now" (0 = Jan, 11 = Dec)
+  currentYear: number
+  fallback: number
+}
+
 /**
  * Computes the historical savings rate as the arithmetic mean of the savings rate
  * of the last completed months (up to 3). Months with no income are excluded.
  * Falls back to the current month's savings rate when no historical data is available.
  */
-export const computeHistoricalSavingsRate = (
-  last6Months: MonthlyData[],
-  currentMonthIndex: number,  // 0-indexed month of "now" (0 = Jan, 11 = Dec)
-  currentYear: number,
-  fallback: number
-): number => {
+export const computeHistoricalSavingsRate = ({
+  last6Months,
+  currentMonthIndex,
+  currentYear,
+  fallback
+}: ComputeHistoricalSavingsRateParams): number => {
   const completedMonths = last6Months.filter(monthData => {
     // Only include strictly past months to avoid distortion from future-dated transactions
     const isPastMonth = monthData.year < currentYear ||

--- a/packages/api/test/services/dashboard.service.test.ts
+++ b/packages/api/test/services/dashboard.service.test.ts
@@ -1,19 +1,107 @@
-import { computeHealthScore } from '../../src/services/dashboard/health-score'
+import { computeHealthScore, computeSavingsScore, computeHistoricalSavingsRate } from '../../src/services/dashboard/health-score'
+
+describe('computeSavingsScore', () => {
+  test('rate <= 0 returns 0', () => {
+    expect(computeSavingsScore(0)).toBe(0)
+    expect(computeSavingsScore(-5)).toBe(0)
+    expect(computeSavingsScore(-100)).toBe(0)
+  })
+
+  test('rate in 0–5% range maps to 0–30 pts', () => {
+    // 0% → 0, 5% → 30
+    expect(computeSavingsScore(0)).toBe(0)
+    expect(computeSavingsScore(2.5)).toBe(15)
+    expect(computeSavingsScore(5)).toBe(30)
+  })
+
+  test('rate in 5–15% range maps to 30–70 pts', () => {
+    // 5% → 30, 10% → 50, 15% → 70
+    expect(computeSavingsScore(5)).toBe(30)
+    expect(computeSavingsScore(10)).toBe(50)
+    expect(computeSavingsScore(15)).toBe(70)
+  })
+
+  test('rate in 15–30% range maps to 70–100 pts', () => {
+    // 15% → 70, 22.5% → 85, 30% → 100
+    expect(computeSavingsScore(15)).toBe(70)
+    expect(computeSavingsScore(22.5)).toBe(85)
+    expect(computeSavingsScore(30)).toBe(100)
+  })
+
+  test('rate above 30% is capped at 100', () => {
+    expect(computeSavingsScore(40)).toBe(100)
+    expect(computeSavingsScore(100)).toBe(100)
+  })
+})
+
+describe('computeHistoricalSavingsRate', () => {
+  const currentMonth = 4  // May (0-indexed)
+  const currentYear = 2026
+
+  test('returns fallback when no months with income are available', () => {
+    expect(computeHistoricalSavingsRate([], currentMonth, currentYear, 15)).toBe(15)
+  })
+
+  test('excludes the current in-progress month', () => {
+    const months = [
+      { month: 5, year: 2026, income: 2000, expenses: 1000 }, // current → excluded
+      { month: 4, year: 2026, income: 2000, expenses: 1200 }, // April → 40%
+    ]
+    // Only April qualifies: (2000-1200)/2000 * 100 = 40%
+    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(40)
+  })
+
+  test('excludes months with no income', () => {
+    const months = [
+      { month: 3, year: 2026, income: 0, expenses: 500 },    // no income → excluded
+      { month: 2, year: 2026, income: 2000, expenses: 1600 }, // 20%
+      { month: 1, year: 2026, income: 2000, expenses: 1800 }, // 10%
+    ]
+    // avg of 20% and 10% = 15%
+    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(15)
+  })
+
+  test('uses only the last 3 completed months', () => {
+    const months = [
+      { month: 11, year: 2025, income: 2000, expenses: 1000 }, // 50% — oldest, excluded (4th)
+      { month: 12, year: 2025, income: 2000, expenses: 1200 }, // 40%
+      { month: 1, year: 2026, income: 2000, expenses: 1400 },  // 30%
+      { month: 2, year: 2026, income: 2000, expenses: 1600 },  // 20%
+    ]
+    // avg of last 3: (40 + 30 + 20) / 3 ≈ 30
+    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(30)
+  })
+
+  test('returns fallback when all months are zero income', () => {
+    const months = [
+      { month: 2, year: 2026, income: 0, expenses: 500 },
+      { month: 1, year: 2026, income: 0, expenses: 300 },
+    ]
+    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 25)).toBe(25)
+  })
+})
 
 describe('computeHealthScore', () => {
-  test('all perfect inputs should yield a total near 100', () => {
-    // savingsRate >= 20% → savingsScore 100
+  test('all perfect inputs should yield a total of 95', () => {
+    // savingsRate >= 30% → savingsScore 100, but rate=20% → savingsScore 80
     // totalDebts = 0 → debtScore 100
     // budgetAdherencePct = 100 → budgetScore 100
     // cashRunwayMonths >= 6 → runwayScore 100
     // pensionReturnPct >= 5% → pensionScore 100
+    // total = round(80*0.25 + 100*0.20 + 100*0.20 + 100*0.20 + 100*0.15) = round(20+20+20+20+15) = 95
     const result = computeHealthScore(20, 0, 10000, 100, 6, 5)
-    expect(result.total).toBe(100)
-    expect(result.savingsRate).toBe(100)
+    expect(result.total).toBe(95)
+    expect(result.savingsRate).toBe(80)
     expect(result.debtRatio).toBe(100)
     expect(result.budgetAdherence).toBe(100)
     expect(result.cashRunway).toBe(100)
     expect(result.pensionReturn).toBe(100)
+  })
+
+  test('savingsRate >= 30% yields a perfect total of 100', () => {
+    const result = computeHealthScore(30, 0, 10000, 100, 6, 5)
+    expect(result.savingsRate).toBe(100)
+    expect(result.total).toBe(100)
   })
 
   test('all zero inputs should yield a total of 0', () => {
@@ -27,16 +115,23 @@ describe('computeHealthScore', () => {
     expect(result.pensionReturn).toBe(0)
   })
 
-  test('savingsRate sub-score scales linearly up to 20%', () => {
+  test('savingsRate sub-score uses progressive scale', () => {
+    // 10% → 30 + ((10-5)/10)*40 = 50
     const at10 = computeHealthScore(10, 0, 0, 0, 0, 0)
     expect(at10.savingsRate).toBe(50)
 
+    // 20% → 70 + ((20-15)/15)*30 = 70+10 = 80
     const at20 = computeHealthScore(20, 0, 0, 0, 0, 0)
-    expect(at20.savingsRate).toBe(100)
+    expect(at20.savingsRate).toBe(80)
 
-    // Capped at 100 even above 20
+    // Capped at 100 above 30%
     const at40 = computeHealthScore(40, 0, 0, 0, 0, 0)
     expect(at40.savingsRate).toBe(100)
+  })
+
+  test('negative savingsRate yields savingsScore of 0', () => {
+    const result = computeHealthScore(-10, 0, 10000, 0, 0, 0)
+    expect(result.savingsRate).toBe(0)
   })
 
   test('debtRatio sub-score is 100 when no debts and positive balance', () => {
@@ -81,27 +176,33 @@ describe('computeHealthScore', () => {
   })
 
   test('total is weighted sum of sub-scores (25/20/20/20/15)', () => {
-    // Concrete case: savingsScore=80, debtScore=60, budgetScore=70, runwayScore=50, pensionScore=40
-    // savingsRate = 16% → 16/20 * 100 = 80
-    // debts = 2000, balance = 5000 → (1 - 2000/5000) * 100 = 60
-    // budgetAdherence = 70
-    // cashRunway = 3 months → 3/6 * 100 = 50
-    // pensionReturn = 2% → 2/5 * 100 = 40
-    // total = round(80*0.25 + 60*0.20 + 70*0.20 + 50*0.20 + 40*0.15)
-    //       = round(20 + 12 + 14 + 10 + 6) = round(62) = 62
+    // savingsRate=16% → 70 + ((16-15)/15)*30 = 70+2 = 72
+    // debts=2000, balance=5000 → (1-2000/5000)*100 = 60
+    // budgetAdherence=70
+    // cashRunway=3 → 3/6*100 = 50
+    // pensionReturn=2% → 2/5*100 = 40
+    // total = round(72*0.25 + 60*0.20 + 70*0.20 + 50*0.20 + 40*0.15)
+    //       = round(18 + 12 + 14 + 10 + 6) = round(60) = 60
     const result = computeHealthScore(16, 2000, 5000, 70, 3, 2)
-    expect(result.savingsRate).toBe(80)
+    expect(result.savingsRate).toBe(72)
     expect(result.debtRatio).toBe(60)
     expect(result.budgetAdherence).toBe(70)
     expect(result.cashRunway).toBe(50)
     expect(result.pensionReturn).toBe(40)
-    expect(result.total).toBe(62)
+    expect(result.total).toBe(60)
   })
 
   test('all sub-scores are rounded to integers (Math.round applied)', () => {
+    // savingsRate=7% → 30 + ((7-5)/10)*40 = 30+8 = 38
+    // debts=1234, balance=5678 → (1-1234/5678)*100 ≈ 78
+    // budgetAdherence=67
+    // cashRunway=2.5 → 2.5/6*100 ≈ 42
+    // pensionReturn=1.7% → 1.7/5*100 = 34
+    // total = round(38*0.25 + 78*0.20 + 67*0.20 + 42*0.20 + 34*0.15)
+    //       = round(9.5 + 15.6 + 13.4 + 8.4 + 5.1) = round(52) = 52
     const result = computeHealthScore(7, 1234, 5678, 67, 2.5, 1.7)
-    expect(result.total).toBe(51)
-    expect(result.savingsRate).toBe(35)
+    expect(result.total).toBe(52)
+    expect(result.savingsRate).toBe(38)
     expect(result.debtRatio).toBe(78)
     expect(result.budgetAdherence).toBe(67)
     expect(result.cashRunway).toBe(42)

--- a/packages/api/test/services/dashboard.service.test.ts
+++ b/packages/api/test/services/dashboard.service.test.ts
@@ -7,6 +7,10 @@ describe('computeSavingsScore', () => {
     expect(computeSavingsScore(-100)).toBe(0)
   })
 
+  test('NaN rate returns 0 instead of 100', () => {
+    expect(computeSavingsScore(NaN)).toBe(0)
+  })
+
   test('rate in 0–5% range maps to 0–30 pts', () => {
     // 0% → 0, 5% → 30
     expect(computeSavingsScore(0)).toBe(0)
@@ -78,6 +82,17 @@ describe('computeHistoricalSavingsRate', () => {
       { month: 1, year: 2026, income: 0, expenses: 300 },
     ]
     expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 25)).toBe(25)
+  })
+
+  test('excludes future-dated months', () => {
+    const months = [
+      { month: 6, year: 2026, income: 2000, expenses: 500 },  // future (June) → excluded
+      { month: 7, year: 2026, income: 2000, expenses: 400 },  // future (July) → excluded
+      { month: 4, year: 2026, income: 2000, expenses: 1200 }, // April → 40%
+      { month: 3, year: 2026, income: 2000, expenses: 1400 }, // March → 30%
+    ]
+    // Only April and March qualify: (40 + 30) / 2 = 35%
+    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(35)
   })
 })
 

--- a/packages/api/test/services/dashboard.service.test.ts
+++ b/packages/api/test/services/dashboard.service.test.ts
@@ -43,7 +43,7 @@ describe('computeHistoricalSavingsRate', () => {
   const currentYear = 2026
 
   test('returns fallback when no months with income are available', () => {
-    expect(computeHistoricalSavingsRate([], currentMonth, currentYear, 15)).toBe(15)
+    expect(computeHistoricalSavingsRate({ last6Months: [], currentMonthIndex: currentMonth, currentYear, fallback: 15 })).toBe(15)
   })
 
   test('excludes the current in-progress month', () => {
@@ -52,7 +52,7 @@ describe('computeHistoricalSavingsRate', () => {
       { month: 4, year: 2026, income: 2000, expenses: 1200 }, // April → 40%
     ]
     // Only April qualifies: (2000-1200)/2000 * 100 = 40%
-    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(40)
+    expect(computeHistoricalSavingsRate({ last6Months: months, currentMonthIndex: currentMonth, currentYear, fallback: 0 })).toBe(40)
   })
 
   test('excludes months with no income', () => {
@@ -62,7 +62,7 @@ describe('computeHistoricalSavingsRate', () => {
       { month: 1, year: 2026, income: 2000, expenses: 1800 }, // 10%
     ]
     // avg of 20% and 10% = 15%
-    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(15)
+    expect(computeHistoricalSavingsRate({ last6Months: months, currentMonthIndex: currentMonth, currentYear, fallback: 0 })).toBe(15)
   })
 
   test('uses only the last 3 completed months', () => {
@@ -73,7 +73,7 @@ describe('computeHistoricalSavingsRate', () => {
       { month: 2, year: 2026, income: 2000, expenses: 1600 },  // 20%
     ]
     // avg of last 3: (40 + 30 + 20) / 3 ≈ 30
-    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(30)
+    expect(computeHistoricalSavingsRate({ last6Months: months, currentMonthIndex: currentMonth, currentYear, fallback: 0 })).toBe(30)
   })
 
   test('returns fallback when all months are zero income', () => {
@@ -81,7 +81,7 @@ describe('computeHistoricalSavingsRate', () => {
       { month: 2, year: 2026, income: 0, expenses: 500 },
       { month: 1, year: 2026, income: 0, expenses: 300 },
     ]
-    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 25)).toBe(25)
+    expect(computeHistoricalSavingsRate({ last6Months: months, currentMonthIndex: currentMonth, currentYear, fallback: 25 })).toBe(25)
   })
 
   test('excludes future-dated months', () => {
@@ -92,7 +92,7 @@ describe('computeHistoricalSavingsRate', () => {
       { month: 3, year: 2026, income: 2000, expenses: 1400 }, // March → 30%
     ]
     // Only April and March qualify: (40 + 30) / 2 = 35%
-    expect(computeHistoricalSavingsRate(months, currentMonth, currentYear, 0)).toBe(35)
+    expect(computeHistoricalSavingsRate({ last6Months: months, currentMonthIndex: currentMonth, currentYear, fallback: 0 })).toBe(35)
   })
 })
 


### PR DESCRIPTION
## Summary
- Use the average savings rate from the last 3 completed months for the dashboard health score, avoiding distortion from the in-progress month.
- Replace the linear savings score with a progressive curve that caps at 30% savings and keeps negative/zero savings at 0 points.
- Add test coverage for savings score ranges, historical savings rate fallback/exclusions, and updated weighted score expectations.

## Verification
- `pnpm --filter @soker90/finper-api exec tsc --noEmit`
- `pnpm --filter @soker90/finper-api exec jest test/services/dashboard.service.test.ts`
- `pnpm --filter @soker90/finper-api exec jest test/routes/dashboard.routes.test.ts`
- Commit hooks ran full package tests successfully during both commits.