### PR TITLE
fix: add store autocomplete to ticket review modal

### DIFF
--- a/packages/client/src/components/forms/AutocompleteForm.tsx
+++ b/packages/client/src/components/forms/AutocompleteForm.tsx
@@ -40,7 +40,6 @@ const AutocompleteForm = ({
         <InputLabel htmlFor={id}>{label}</InputLabel>
         <Autocomplete
           disableClearable
-          sx={{ input: { height: 8 } }}
           freeSolo
           selectOnFocus
           options={options}

--- a/packages/client/src/components/forms/AutocompleteForm.tsx
+++ b/packages/client/src/components/forms/AutocompleteForm.tsx
@@ -44,7 +44,7 @@ const AutocompleteForm = ({
           freeSolo
           selectOnFocus
           options={options}
-          getOptionLabel={(option: any) => option[optionLabel]}
+          getOptionLabel={(option: any) => typeof option === 'string' ? option : option[optionLabel]}
           fullWidth
           noOptionsText=''
           defaultValue={defaultValue}

--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -33,19 +33,11 @@ const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }:
                 textField: {
                   variant: 'outlined',
                   error
-                },
-                inputAdornment: {
-                  sx: { ml: 0 }
-                },
-                openPickerButton: {
-                  sx: { p: '8px' }
-                },
-                field: {
-                  sx: {
-                    '& .MuiPickersSectionList-root': {
-                      padding: '16.5px 14px'
-                    }
-                  }
+                }
+              }}
+              sx={{
+                '& .MuiPickersSectionList-root': {
+                  padding: '16.5px 14px'
                 }
               }}
               onChange={onChange}

--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -33,6 +33,19 @@ const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }:
                 textField: {
                   variant: 'outlined',
                   error
+                },
+                inputAdornment: {
+                  sx: { ml: 0 }
+                },
+                openPickerButton: {
+                  sx: { p: '8px' }
+                },
+                field: {
+                  sx: {
+                    '& .MuiPickersSectionList-root': {
+                      padding: '16.5px 14px'
+                    }
+                  }
                 }
               }}
               onChange={onChange}

--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -33,11 +33,13 @@ const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }:
                 textField: {
                   variant: 'outlined',
                   error
-                }
-              }}
-              sx={{
-                '& .MuiPickersSectionList-root': {
-                  padding: '16.5px 14px'
+                },
+                field: {
+                  sx: {
+                    '& .MuiPickersSectionList-root': {
+                      padding: '10.5px 14px'
+                    }
+                  }
                 }
               }}
               onChange={onChange}

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -82,6 +82,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         placeholder='Fecha del ticket' id='date' label='Fecha'
         error={!!errors.date}
         control={control}
+        size={6}
       />
 
       <SelectForm
@@ -91,7 +92,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         optionLabel='name'
         error={!!errors.account} {...register('account', { required: true })}
         errorText='Selecciona una cuenta'
-        size={2}
+        size={6}
       />
 
       <SelectForm
@@ -99,7 +100,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         options={TYPES_TRANSACTIONS_ENTRIES}
         optionValue={0}
         optionLabel={1}
-        size={2}
+        size={6}
         error={!!errors.type} {...register('type', { required: true })}
       />
 
@@ -110,7 +111,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         optionLabel='name'
         error={!!errors.category} {...register('category', { required: true })}
         errorText='Selecciona una categoría'
-        size={2}
+        size={6}
       />
 
       <InputForm
@@ -118,7 +119,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         error={!!errors.amount} {...register('amount', { required: true, valueAsNumber: true })}
         errorText='Introduce un importe válido'
         type='number' inputProps={{ step: 'any' }}
-        size={2}
+        size={6}
       />
 
       <AutocompleteForm
@@ -127,7 +128,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         placeholder='Comercio'
         error={!!errors.store}
         errorText='Introduce un comercio válido'
-        size={2}
+        size={6}
         {...register('store')}
         {...(ticket.store && { defaultValue: ticket.store })}
       />

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -4,10 +4,11 @@ import { Alert, FormHelperText, Grid } from '@mui/material'
 import { mutate } from 'swr'
 
 import { ModalGrid, DateForm, InputForm, SelectForm, SelectGroupForm } from 'components'
+import AutocompleteForm from 'components/forms/AutocompleteForm'
 import { addTransaction } from 'services/apiService'
 import { TRANSACTIONS } from 'constants/api-paths'
 import { Ticket, TransactionType, TRANSACTION } from 'types'
-import { useAccounts, useGroupedCategories, useTickets } from 'hooks'
+import { useAccounts, useGroupedCategories, useTickets, useStores } from 'hooks'
 import { TYPES_TRANSACTIONS_ENTRIES } from 'constants/transactions'
 
 interface Props {
@@ -27,6 +28,7 @@ interface FormValues {
 const ReviewModal = ({ ticket, onClose }: Props) => {
   const { accounts } = useAccounts()
   const { categories } = useGroupedCategories()
+  const { stores } = useStores()
   const { markReviewed } = useTickets()
   const [error, setError] = useState<string | undefined>(undefined)
 
@@ -119,11 +121,14 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         size={2}
       />
 
-      <InputForm
-        id='store' label='Comercio' placeholder='Nombre del comercio'
-        error={!!errors.store} {...register('store')}
-        errorText=''
+      <AutocompleteForm
+        options={stores}
+        optionLabel='name' id='store' label='Comercio'
+        placeholder='Comercio'
+        error={!!errors.store}
+        errorText='Introduce un comercio válido'
         size={2}
+        {...register('store')}
       />
 
       {ticket.payment_method && (

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -129,6 +129,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         errorText='Introduce un comercio válido'
         size={2}
         {...register('store')}
+        {...(ticket.store && { defaultValue: ticket.store })}
       />
 
       {ticket.payment_method && (


### PR DESCRIPTION
Replaced simple InputForm with AutocompleteForm for store field in the ticket review modal. Now loads available stores via useStores hook and provides autocomplete suggestions, matching the UX of the TransactionEdit form. Users can still enter custom store names if not found in the list.