### PR TITLE
feat: add info tooltips to health score items and clarify savings rate label

### DIFF
--- a/packages/client/src/components/forms/AutocompleteForm.tsx
+++ b/packages/client/src/components/forms/AutocompleteForm.tsx
@@ -40,7 +40,6 @@ const AutocompleteForm = ({
         <InputLabel htmlFor={id}>{label}</InputLabel>
         <Autocomplete
           disableClearable
-          sx={{ input: { height: 8 } }}
           freeSolo
           selectOnFocus
           options={options}

--- a/packages/client/src/components/forms/AutocompleteForm.tsx
+++ b/packages/client/src/components/forms/AutocompleteForm.tsx
@@ -44,7 +44,7 @@ const AutocompleteForm = ({
           freeSolo
           selectOnFocus
           options={options}
-          getOptionLabel={(option: any) => option[optionLabel]}
+          getOptionLabel={(option: any) => typeof option === 'string' ? option : option[optionLabel]}
           fullWidth
           noOptionsText=''
           defaultValue={defaultValue}

--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -33,19 +33,11 @@ const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }:
                 textField: {
                   variant: 'outlined',
                   error
-                },
-                inputAdornment: {
-                  sx: { ml: 0 }
-                },
-                openPickerButton: {
-                  sx: { p: '8px' }
-                },
-                field: {
-                  sx: {
-                    '& .MuiPickersSectionList-root': {
-                      padding: '16.5px 14px'
-                    }
-                  }
+                }
+              }}
+              sx={{
+                '& .MuiPickersSectionList-root': {
+                  padding: '16.5px 14px'
                 }
               }}
               onChange={onChange}

--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -33,6 +33,19 @@ const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }:
                 textField: {
                   variant: 'outlined',
                   error
+                },
+                inputAdornment: {
+                  sx: { ml: 0 }
+                },
+                openPickerButton: {
+                  sx: { p: '8px' }
+                },
+                field: {
+                  sx: {
+                    '& .MuiPickersSectionList-root': {
+                      padding: '16.5px 14px'
+                    }
+                  }
                 }
               }}
               onChange={onChange}

--- a/packages/client/src/components/forms/DateForm.tsx
+++ b/packages/client/src/components/forms/DateForm.tsx
@@ -33,11 +33,13 @@ const DateForm = ({ id, label, control, error, errorText, size = 4, ...others }:
                 textField: {
                   variant: 'outlined',
                   error
-                }
-              }}
-              sx={{
-                '& .MuiPickersSectionList-root': {
-                  padding: '16.5px 14px'
+                },
+                field: {
+                  sx: {
+                    '& .MuiPickersSectionList-root': {
+                      padding: '10.5px 14px'
+                    }
+                  }
                 }
               }}
               onChange={onChange}

--- a/packages/client/src/pages/Dashboard/Dashboard.test.tsx
+++ b/packages/client/src/pages/Dashboard/Dashboard.test.tsx
@@ -67,7 +67,7 @@ describe('Dashboard', () => {
     it('renders Tasa de Ahorro and Deudas Totales labels', async () => {
       const { findByText } = render(<Dashboard />)
 
-      expect(await findByText('Tasa de Ahorro')).toBeDefined()
+      expect(await findByText('Tasa de Ahorro (mes actual)')).toBeDefined()
       expect(await findByText('Deudas Totales')).toBeDefined()
     })
   })

--- a/packages/client/src/pages/Dashboard/components/TrendsSection.tsx
+++ b/packages/client/src/pages/Dashboard/components/TrendsSection.tsx
@@ -110,7 +110,7 @@ const TrendsSection = ({ stats, tickets, chartHeight }: TrendsSectionProps) => {
 
               {/* Tasa de ahorro */}
               <MiniKpi
-                title='Tasa de Ahorro'
+                title='Tasa de Ahorro (mes actual)'
                 value={`${stats.savingsRate.toFixed(1)}%`}
                 icon={<DollarOutlined />}
                 color={stats.savingsRate >= 20 ? 'success' : 'warning'}

--- a/packages/client/src/pages/Dashboard/components/health-score/ScoreGauge.tsx
+++ b/packages/client/src/pages/Dashboard/components/health-score/ScoreGauge.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@mui/material/styles'
-import { Stack, Box, Typography, LinearProgress } from '@mui/material'
+import { Stack, Box, Typography, LinearProgress, Tooltip } from '@mui/material'
+import { InfoCircleOutlined } from '@ant-design/icons'
 import { RadialBarChart, RadialBar, ResponsiveContainer } from 'recharts'
 import { type HealthScore } from 'hooks'
 import { getScoreColor } from '../../utils/scoreHelpers'
@@ -9,11 +10,31 @@ interface ScoreGaugeProps {
 }
 
 const SCORE_ITEMS = [
-  { label: 'Tasa de ahorro', key: 'savingsRate' },
-  { label: 'Ratio deuda', key: 'debtRatio' },
-  { label: 'Presupuesto', key: 'budgetAdherence' },
-  { label: 'Colchón', key: 'cashRunway' },
-  { label: 'Pensión', key: 'pensionReturn' }
+  {
+    label: 'Tasa de ahorro',
+    key: 'savingsRate',
+    tooltip: 'Media de (ingresos − gastos) / ingresos de los últimos 3 meses completados. Representa el 25% del score total.'
+  },
+  {
+    label: 'Ratio deuda',
+    key: 'debtRatio',
+    tooltip: 'Proporción de deudas sobre el patrimonio neto. Representa el 20% del score total.'
+  },
+  {
+    label: 'Presupuesto',
+    key: 'budgetAdherence',
+    tooltip: 'Cumplimiento del presupuesto mensual. Representa el 20% del score total.'
+  },
+  {
+    label: 'Colchón',
+    key: 'cashRunway',
+    tooltip: 'Meses de gastos cubiertos con el saldo disponible actual. Representa el 20% del score total.'
+  },
+  {
+    label: 'Pensión',
+    key: 'pensionReturn',
+    tooltip: 'Rentabilidad del plan de pensión. Representa el 15% del score total.'
+  }
 ] as const
 
 const ScoreGauge = ({ healthScore }: ScoreGaugeProps) => {
@@ -65,9 +86,14 @@ const ScoreGauge = ({ healthScore }: ScoreGaugeProps) => {
       <Stack spacing={0.75} sx={{ width: '100%', pt: 1 }}>
         {SCORE_ITEMS.map(item => (
           <Stack key={item.label} direction='row' alignItems='center' spacing={1}>
-            <Typography variant='body2' color='textSecondary' sx={{ minWidth: 100 }}>
-              {item.label}
-            </Typography>
+            <Stack direction='row' alignItems='center' sx={{ minWidth: 100 }}>
+              <Typography variant='body2' color='textSecondary'>
+                {item.label}
+              </Typography>
+              <Tooltip title={item.tooltip} arrow placement='top'>
+                <InfoCircleOutlined style={{ fontSize: 13, color: 'rgba(0,0,0,0.38)', marginLeft: 3, cursor: 'default' }} />
+              </Tooltip>
+            </Stack>
             <LinearProgress
               variant='determinate'
               value={healthScore[item.key]}

--- a/packages/client/src/pages/Dashboard/components/health-score/ScoreGauge.tsx
+++ b/packages/client/src/pages/Dashboard/components/health-score/ScoreGauge.tsx
@@ -91,7 +91,7 @@ const ScoreGauge = ({ healthScore }: ScoreGaugeProps) => {
                 {item.label}
               </Typography>
               <Tooltip title={item.tooltip} arrow placement='top'>
-                <InfoCircleOutlined style={{ fontSize: 13, color: 'rgba(0,0,0,0.38)', marginLeft: 3, cursor: 'default' }} />
+                <InfoCircleOutlined style={{ fontSize: 13, color: theme.palette.text.secondary, marginLeft: 3, cursor: 'default' }} />
               </Tooltip>
             </Stack>
             <LinearProgress

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -82,6 +82,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         placeholder='Fecha del ticket' id='date' label='Fecha'
         error={!!errors.date}
         control={control}
+        size={6}
       />
 
       <SelectForm
@@ -91,7 +92,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         optionLabel='name'
         error={!!errors.account} {...register('account', { required: true })}
         errorText='Selecciona una cuenta'
-        size={2}
+        size={6}
       />
 
       <SelectForm
@@ -99,7 +100,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         options={TYPES_TRANSACTIONS_ENTRIES}
         optionValue={0}
         optionLabel={1}
-        size={2}
+        size={6}
         error={!!errors.type} {...register('type', { required: true })}
       />
 
@@ -110,7 +111,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         optionLabel='name'
         error={!!errors.category} {...register('category', { required: true })}
         errorText='Selecciona una categoría'
-        size={2}
+        size={6}
       />
 
       <InputForm
@@ -118,7 +119,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         error={!!errors.amount} {...register('amount', { required: true, valueAsNumber: true })}
         errorText='Introduce un importe válido'
         type='number' inputProps={{ step: 'any' }}
-        size={2}
+        size={6}
       />
 
       <AutocompleteForm
@@ -127,7 +128,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         placeholder='Comercio'
         error={!!errors.store}
         errorText='Introduce un comercio válido'
-        size={2}
+        size={6}
         {...register('store')}
         {...(ticket.store && { defaultValue: ticket.store })}
       />

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -4,10 +4,11 @@ import { Alert, FormHelperText, Grid } from '@mui/material'
 import { mutate } from 'swr'
 
 import { ModalGrid, DateForm, InputForm, SelectForm, SelectGroupForm } from 'components'
+import AutocompleteForm from 'components/forms/AutocompleteForm'
 import { addTransaction } from 'services/apiService'
 import { TRANSACTIONS } from 'constants/api-paths'
 import { Ticket, TransactionType, TRANSACTION } from 'types'
-import { useAccounts, useGroupedCategories, useTickets } from 'hooks'
+import { useAccounts, useGroupedCategories, useTickets, useStores } from 'hooks'
 import { TYPES_TRANSACTIONS_ENTRIES } from 'constants/transactions'
 
 interface Props {
@@ -27,6 +28,7 @@ interface FormValues {
 const ReviewModal = ({ ticket, onClose }: Props) => {
   const { accounts } = useAccounts()
   const { categories } = useGroupedCategories()
+  const { stores } = useStores()
   const { markReviewed } = useTickets()
   const [error, setError] = useState<string | undefined>(undefined)
 
@@ -119,11 +121,14 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         size={2}
       />
 
-      <InputForm
-        id='store' label='Comercio' placeholder='Nombre del comercio'
-        error={!!errors.store} {...register('store')}
-        errorText=''
+      <AutocompleteForm
+        options={stores}
+        optionLabel='name' id='store' label='Comercio'
+        placeholder='Comercio'
+        error={!!errors.store}
+        errorText='Introduce un comercio válido'
         size={2}
+        {...register('store')}
       />
 
       {ticket.payment_method && (

--- a/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
+++ b/packages/client/src/pages/Tickets/components/ReviewModal/index.tsx
@@ -129,6 +129,7 @@ const ReviewModal = ({ ticket, onClose }: Props) => {
         errorText='Introduce un comercio válido'
         size={2}
         {...register('store')}
+        {...(ticket.store && { defaultValue: ticket.store })}
       />
 
       {ticket.payment_method && (


### PR DESCRIPTION
## Summary

- Añade un icono `ⓘ` (`InfoCircleOutlined` de `@ant-design/icons`) junto a cada métrica del score financiero en `ScoreGauge`
- Al pulsar/hover sobre el icono se muestra un tooltip explicando qué mide la métrica y qué peso tiene sobre el score total (25%, 20%, 20%, 20%, 15%)
- Renombra el título `'Tasa de Ahorro'` en `TrendsSection` a `'Tasa de Ahorro (mes actual)'` para diferenciarlo del score, que usa la media de los últimos 3 meses completados
- Actualiza el test de `Dashboard` para reflejar el nuevo label