### PR TITLE
feat: add 'Ver todo' button to Top Stores dashboard card

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/pages/Dashboard/components/month-analysis/MonthAnalysis.tsx
+++ b/packages/client/src/pages/Dashboard/components/month-analysis/MonthAnalysis.tsx
@@ -20,6 +20,7 @@ const MonthAnalysis = ({ stats, chartColors }: MonthAnalysisProps) => (
 
     <TopStoresChart
       items={stats.topStores}
+      chartColors={chartColors}
       growTimeout={1350}
     />
   </>

--- a/packages/client/src/pages/Dashboard/components/month-analysis/TopStoresChart/index.tsx
+++ b/packages/client/src/pages/Dashboard/components/month-analysis/TopStoresChart/index.tsx
@@ -1,81 +1,106 @@
-import { Grid, Grow, Stack, Typography } from '@mui/material'
-import { ShopOutlined } from '@ant-design/icons'
+import { Grid, Grow, Stack, Typography, Button } from '@mui/material'
+import { ShopOutlined, UnorderedListOutlined } from '@ant-design/icons'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { useTheme } from '@mui/material/styles'
+import { useState } from 'react'
 import { format } from 'utils'
 import MainCard from 'components/MainCard'
 import { hoverCardSx } from '../../shared'
+import CategoryBreakdownModal from '../CategoryBreakdownModal'
 import StoreTooltip from './StoreTooltip'
 
 interface TopStoresChartProps {
   items: Array<{ name: string; amount: number }>
+  chartColors: string[]
   growTimeout?: number
 }
 
-const TopStoresChart = ({ items, growTimeout = 1350 }: TopStoresChartProps) => {
+const TopStoresChart = ({ items, chartColors, growTimeout = 1350 }: TopStoresChartProps) => {
+  const [modalOpen, setModalOpen] = useState(false)
   const theme = useTheme()
 
   const data = items.slice(0, 8)
   const max = data[0]?.amount ?? 1
 
   return (
-    <Grow in timeout={growTimeout}>
-      <Grid size={{ xs: 12, md: 6 }}>
-        <MainCard
-          title='Top tiendas'
-          sx={hoverCardSx}
-          secondary={
-            <Stack direction='row' alignItems='center' gap={0.5}>
-              <ShopOutlined style={{ fontSize: 14 }} />
-              <Typography variant='body2' color='textSecondary'>Este mes</Typography>
-            </Stack>
-          }
-        >
-          {data.length === 0
-            ? (
-              <Typography variant='body1' color='textSecondary'>
-                No hay tiendas registradas este mes
-              </Typography>
-              )
-            : (
-              <ResponsiveContainer width='100%' height={Math.max(data.length * 40, 200)}>
-                <BarChart
-                  data={data}
-                  layout='vertical'
-                  margin={{ top: 0, right: 16, bottom: 0, left: 0 }}
+    <>
+      <Grow in timeout={growTimeout}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <MainCard
+            title='Top tiendas'
+            sx={hoverCardSx}
+            secondary={
+              <Stack direction='row' alignItems='center' gap={1}>
+                <Stack direction='row' alignItems='center' gap={0.5}>
+                  <ShopOutlined style={{ fontSize: 14 }} />
+                  <Typography variant='body2' color='textSecondary'>Este mes</Typography>
+                </Stack>
+                <Button
+                  size='small'
+                  variant='text'
+                  startIcon={<UnorderedListOutlined />}
+                  onClick={() => setModalOpen(true)}
+                  disabled={items.length === 0}
                 >
-                  <XAxis
-                    type='number'
-                    tick={{ fontSize: 11 }}
-                    tickFormatter={(v) => format.euro(v)}
-                    axisLine={false}
-                    tickLine={false}
-                    domain={[0, max]}
-                  />
-                  <YAxis
-                    type='category'
-                    dataKey='name'
-                    width={110}
-                    tick={{ fontSize: 12 }}
-                    axisLine={false}
-                    tickLine={false}
-                  />
-                  <Tooltip content={<StoreTooltip />} cursor={{ fill: theme.palette.action.hover }} />
-                  <Bar dataKey='amount' radius={[0, 4, 4, 0]} maxBarSize={24}>
-                    {data.map((entry, index) => (
-                      <Cell
-                        key={entry.name}
-                        fill={index === 0 ? theme.palette.primary.main : theme.palette.primary.light}
-                        fillOpacity={1 - index * 0.07}
-                      />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-              )}
-        </MainCard>
-      </Grid>
-    </Grow>
+                  Ver todo
+                </Button>
+              </Stack>
+            }
+          >
+            {data.length === 0
+              ? (
+                <Typography variant='body1' color='textSecondary'>
+                  No hay tiendas registradas este mes
+                </Typography>
+                )
+              : (
+                <ResponsiveContainer width='100%' height={Math.max(data.length * 40, 200)}>
+                  <BarChart
+                    data={data}
+                    layout='vertical'
+                    margin={{ top: 0, right: 16, bottom: 0, left: 0 }}
+                  >
+                    <XAxis
+                      type='number'
+                      tick={{ fontSize: 11 }}
+                      tickFormatter={(v) => format.euro(v)}
+                      axisLine={false}
+                      tickLine={false}
+                      domain={[0, max]}
+                    />
+                    <YAxis
+                      type='category'
+                      dataKey='name'
+                      width={110}
+                      tick={{ fontSize: 12 }}
+                      axisLine={false}
+                      tickLine={false}
+                    />
+                    <Tooltip content={<StoreTooltip />} cursor={{ fill: theme.palette.action.hover }} />
+                    <Bar dataKey='amount' radius={[0, 4, 4, 0]} maxBarSize={24}>
+                      {data.map((entry, index) => (
+                        <Cell
+                          key={entry.name}
+                          fill={index === 0 ? theme.palette.primary.main : theme.palette.primary.light}
+                          fillOpacity={1 - index * 0.07}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+                )}
+          </MainCard>
+        </Grid>
+      </Grow>
+
+      <CategoryBreakdownModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title='Tiendas — este mes'
+        items={items}
+        chartColors={chartColors}
+      />
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

Restore the missing "Ver todo" (see all) button to the Top Stores dashboard card. The button opens a modal showing all stores for the current month with their respective amounts and percentages, using the same modal and styling as the Top Expense Categories card.

## Changes

- **TopStoresChart**: Added button state management with `useState` and integrated the "Ver todo" button with list icon
- **MonthAnalysis**: Now passes `chartColors` to `TopStoresChart` component
- **CategoryBreakdownModal**: Reused existing modal component to display all stores with consistent styling

## Features

- Button displays all stores (not just the top 8 shown in the chart)
- Modal shows: store name, percentage of total, and amount in euros
- Uses same color scheme and styling as the category breakdown modal
- Button is disabled when there are no stores

## Testing

- Build completes successfully
- All tests pass (client: 211 passed, api: 643 passed)
- TypeScript check passes with no errors