### PR TITLE
fix(dependabot): add bot package and set pnpm as package manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,10 @@ updates:
     labels:
       - "github-actions"
       - "dependencies"
-      
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/api" # Location of package manifests
+
+  - package-ecosystem: "npm"
+    directory: "/packages/api"
+    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:
@@ -28,9 +29,10 @@ updates:
     labels:
       - "api"
       - "dependencies"
-      
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/client" # Location of package manifests
+
+  - package-ecosystem: "npm"
+    directory: "/packages/client"
+    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:
@@ -40,9 +42,10 @@ updates:
     labels:
       - "ui"
       - "dependencies"
-      
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/models" # Location of package manifests
+
+  - package-ecosystem: "npm"
+    directory: "/packages/models"
+    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:
@@ -51,4 +54,17 @@ updates:
       semver-major: "7 days"
     labels:
       - "models"
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/bot"
+    package-manager: "pnpm"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      semver-patch: "1 day"
+      semver-minor: "7 days"
+      semver-major: "7 days"
+    labels:
+      - "bot"
       - "dependencies"


### PR DESCRIPTION
## Cambios

- Añade entrada para `/packages/bot` que faltaba tras su migración al monorepo (#707)
- Añade `package-manager: pnpm` en los 4 paquetes npm para que Dependabot use pnpm en lugar de npm