### PR TITLE
build(deps-dev): install msw 2.14.6 and pin exact version

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react-hooks": "7.1.1",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",
-    "msw": "^2.14.6",
+    "msw": "2.14.6",
     "neostandard": "^0.13.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
         specifier: ^20.9.0
         version: 20.9.0
       msw:
-        specifier: ^2.14.6
+        specifier: 2.14.6
         version: 2.14.6(@types/node@25.7.0)(typescript@5.9.3)
       neostandard:
         specifier: ^0.13.0
@@ -2811,6 +2811,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -6820,6 +6823,9 @@ packages:
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
@@ -9695,6 +9701,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -9756,7 +9766,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.5.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -14751,6 +14761,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   underscore@1.13.8: {}
+
+  undici-types@7.18.2: {}
 
   undici-types@7.19.2: {}
 


### PR DESCRIPTION
- Actualiza msw a la versión más reciente: 2.14.6
- Fija la versión exacta (elimina el `^`) siguiendo las reglas del proyecto