### PR TITLE
fix(dependabot): use correct cooldown property names per GitHub spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      semver-patch: "1 day"
-      semver-minor: "7 days"
-      semver-major: "7 days"
+      default-days: 7
     labels:
       - "github-actions"
       - "dependencies"
@@ -23,9 +21,9 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      semver-patch: "1 day"
-      semver-minor: "7 days"
-      semver-major: "7 days"
+      semver-patch-days: 1
+      semver-minor-days: 7
+      semver-major-days: 7
     labels:
       - "api"
       - "dependencies"
@@ -36,9 +34,9 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      semver-patch: "1 day"
-      semver-minor: "7 days"
-      semver-major: "7 days"
+      semver-patch-days: 1
+      semver-minor-days: 7
+      semver-major-days: 7
     labels:
       - "ui"
       - "dependencies"
@@ -49,9 +47,9 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      semver-patch: "1 day"
-      semver-minor: "7 days"
-      semver-major: "7 days"
+      semver-patch-days: 1
+      semver-minor-days: 7
+      semver-major-days: 7
     labels:
       - "models"
       - "dependencies"
@@ -62,9 +60,9 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      semver-patch: "1 day"
-      semver-minor: "7 days"
-      semver-major: "7 days"
+      semver-patch-days: 1
+      semver-minor-days: 7
+      semver-major-days: 7
     labels:
       - "bot"
       - "dependencies"


### PR DESCRIPTION
## Problema

El check de Dependabot fallaba en todas las PRs con:

```
The property '#/updates/0/cooldown' contains additional properties ["semver-patch", "semver-minor", "semver-major"] outside of the schema when none are allowed
```

## Causa

Las claves `semver-patch`, `semver-minor` y `semver-major` no son válidas. La [documentación oficial](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown) especifica nombres distintos y valores numéricos (días enteros).

## Cambios

| Antes (incorrecto) | Después (correcto) |
|---|---|
| `semver-patch: "1 day"` | `semver-patch-days: 1` |
| `semver-minor: "7 days"` | `semver-minor-days: 7` |
| `semver-major: "7 days"` | `semver-major-days: 7` |

Para `github-actions` (que no soporta las claves semver específicas) se usa `default-days: 7`.