### PR TITLE
fix(dependabot): remove invalid package-manager property

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/api"
-    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:
@@ -30,7 +29,6 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/client"
-    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:
@@ -43,7 +41,6 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/models"
-    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:
@@ -56,7 +53,6 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/bot"
-    package-manager: "pnpm"
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
La propiedad `package-manager` no existe en el esquema de Dependabot y causaba el error:

```
The property '#/updates/1/' contains additional properties ["package-manager"] outside of the schema when none are allowed
```

Dependabot detecta pnpm automáticamente a través del campo `"packageManager": "pnpm@10.29.3"` del `package.json` raíz (estándar corepack). No se necesita ninguna configuración adicional.