### PR TITLE
chore: bump minor versions - api/client 1.11.0, models 1.9.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-models",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Models for finper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump minor versions across all packages:\n- @soker90/finper-api: 1.10.2 → 1.11.0\n- @soker90/finper-client: 1.10.2 → 1.11.0\n- @soker90/finper-models: 1.8.0 → 1.9.0