### PR TITLE
fix(categories): scope grouped categories by user and fix validator types

### DIFF
--- a/packages/api/src/controllers/category.controller.ts
+++ b/packages/api/src/controllers/category.controller.ts
@@ -41,17 +41,17 @@ export class CategoryController {
     res.send(response)
   }
 
-  public async categoriesGrouped (_req: Request, res: Response): Promise<void> {
+  public async categoriesGrouped (req: Request, res: Response): Promise<void> {
     this.logger.logInfo('/categories - list categories')
 
-    const response = await this.categoryService.getGroupedCategories()
+    const response = await this.categoryService.getGroupedCategories(req.user)
     res.send(response)
   }
 
   public async edit (req: Request, res: Response): Promise<void> {
     this.logger.logInfo(`/edit - category: ${req.body.name}`)
 
-    const params = await validateCategoryEditParams(req)
+    const params = await validateCategoryEditParams({ params: req.params, body: req.body, user: req.user })
     const response = await this.categoryService.editCategory(params)
 
     this.logger.logInfo(`Category ${response._id} has been succesfully edited`)

--- a/packages/api/src/services/category.service.ts
+++ b/packages/api/src/services/category.service.ts
@@ -31,8 +31,12 @@ export default class CategoryService implements ICategoryService {
       {
         $lookup: {
           from: 'categories',
-          localField: '_id',
-          foreignField: 'parent',
+          let: { parentId: '$_id' },
+          pipeline: [
+            { $match: { $expr: { $eq: ['$parent', '$$parentId'] }, user } },
+            { $project: { _id: 1, name: 1 } },
+            { $sort: { name: 1 } }
+          ],
           as: 'children'
         }
       },
@@ -40,13 +44,10 @@ export default class CategoryService implements ICategoryService {
         $project: {
           _id: 1,
           name: 1,
-          children: {
-            _id: 1,
-            name: 1
-          }
+          children: 1
         }
       },
-      { $sort: { name: 1, children: 1 } }
+      { $sort: { name: 1 } }
     ])
   }
 

--- a/packages/api/src/services/category.service.ts
+++ b/packages/api/src/services/category.service.ts
@@ -11,7 +11,7 @@ export interface ICategoryService {
 
   getCategories(user: string): Promise<CategoryDocument[]>
 
-  getGroupedCategories(): Promise<any[]>
+  getGroupedCategories(user: string): Promise<any[]>
 
 }
 
@@ -20,11 +20,12 @@ export default class CategoryService implements ICategoryService {
     return CategoryModel.find({ user }, '_id name type budgetRuleClass').populate('parent', '_id').sort('name')
   }
 
-  public async getGroupedCategories (): Promise<any[]> {
+  public async getGroupedCategories (user: string): Promise<any[]> {
     return CategoryModel.aggregate([
       {
         $match: {
-          parent: { $exists: false }
+          parent: { $exists: false },
+          user
         }
       },
       {

--- a/packages/api/src/validators/category/validate-category-edit-params.ts
+++ b/packages/api/src/validators/category/validate-category-edit-params.ts
@@ -1,7 +1,6 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
-import { TRANSACTION } from '@soker90/finper-models'
-import { ICategory } from '@soker90/finper-models'
+import { TRANSACTION, ICategory } from '@soker90/finper-models'
 import { validateCategoryExist } from './validate-category-exist'
 import { ERROR_MESSAGE } from '../../i18n'
 
@@ -9,11 +8,11 @@ export const validateCategoryEditParams = async ({
   params,
   body,
   user
-}: { params: Record<string, string>, body: Record<string, string>, user?: string }): Promise<{ id: string, value: ICategory }> => {
-  await validateCategoryExist({ id: params.id, user: user as string })
+}: { params: Record<string, string>, body: Record<string, string>, user: string }): Promise<{ id: string, value: ICategory }> => {
+  await validateCategoryExist({ id: params.id, user })
 
   if (body.parent) {
-    await validateCategoryExist({ id: body.parent, message: ERROR_MESSAGE.CATEGORY.PARENT_NOT_FOUND, user: user as string })
+    await validateCategoryExist({ id: body.parent, message: ERROR_MESSAGE.CATEGORY.PARENT_NOT_FOUND, user })
   }
 
   const schema = Joi.object({

--- a/packages/api/test/services/category.service.test.ts
+++ b/packages/api/test/services/category.service.test.ts
@@ -55,7 +55,7 @@ describe('CategoryService', () => {
   // ── getGroupedCategories ──────────────────────────────────────────────────
   describe('getGroupedCategories', () => {
     test('returns empty array when there are no root categories', async () => {
-      const result = await service.getGroupedCategories()
+      const result = await service.getGroupedCategories(generateUsername())
       expect(result).toEqual([])
     })
 
@@ -65,7 +65,7 @@ describe('CategoryService', () => {
       const child = await insertCategory({ user })
       const rootId = (child as any).parent._id.toString()
 
-      const result = await service.getGroupedCategories()
+      const result = await service.getGroupedCategories(user)
       const found = result.find((r: any) => r._id.toString() === rootId)
       expect(found).toBeDefined()
       expect(Array.isArray(found.children)).toBe(true)


### PR DESCRIPTION
- Scope `getGroupedCategories` by `user` — fix security issue reported in PR #743 (was returning all users' categories)
- Revert `user?: string` to `user: string` in `validateCategoryEditParams` — remove unsafe optional + `as string` cast
- Pass explicit `{ params, body, user }` in edit handler instead of `req` directly
- Merge duplicate imports