### PR TITLE
refactor(budgets): migrate budget controller to async/await

### DIFF
--- a/packages/api/src/controllers/budget.controller.ts
+++ b/packages/api/src/controllers/budget.controller.ts
@@ -1,11 +1,8 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
 import '../auth/local-strategy-passport-handler'
 import { IBudgetService } from '../services/budget.service'
-import extractUser from '../helpers/extract-user'
 import { validateBudgetGet, validateBudgetEditParams, validateBudgetCopy } from '../validators/budget'
-import { RequestUser } from '../types'
-import { tap } from '../utils/promise'
 
 type IBudgetController = {
   loggerHandler: any,
@@ -22,48 +19,37 @@ export class BudgetController {
     this.budgetService = budgetService
   }
 
-  public async budgets (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.query)
-      .then(tap(() => this.logger.logInfo(`/budgets - list budgets of ${req.user} ${req.query?.month}/${req.query?.year}`)))
-      .then(validateBudgetGet)
-      .then(extractUser(req))
-      .then(this.budgetService.getBudgets.bind(this.budgetService))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async budgets (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/budgets - list budgets of ${req.user} ${req.query?.month}/${req.query?.year}`)
+
+    const filters = await validateBudgetGet(req.query as Record<string, any>)
+    const response = await this.budgetService.getBudgets({ ...filters, user: req.user })
+
+    res.send(response)
   }
 
-  public async edit (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(({ params }) => this.logger.logInfo(`/edit - category: ${params.category}`)))
-      .then(validateBudgetEditParams)
-      .then(this.budgetService.editBudget.bind(this.budgetService))
-      .then(tap(({ category }) => this.logger.logInfo(`Budget for category ${category} has been succesfully edited`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async edit (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/edit - category: ${req.params.category}`)
+
+    const params = await validateBudgetEditParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.budgetService.editBudget(params)
+
+    this.logger.logInfo(`Budget for category ${response.category} has been succesfully edited`)
+    res.send(response)
   }
 
-  public async copy (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(() => this.logger.logInfo('/copy - budget')))
-      .then(validateBudgetCopy)
-      .then(this.budgetService.copy.bind(this.budgetService))
-      .then(tap(() => this.logger.logInfo('Budget has been succesfully copied')))
-      .then((response) => {
-        if (!response) {
-          res.status(204).send()
-        } else {
-          res.status(201).send()
-        }
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async copy (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo('/copy - budget')
+
+    const params = await validateBudgetCopy({ body: req.body, user: req.user })
+    const response = await this.budgetService.copy(params)
+
+    this.logger.logInfo('Budget has been succesfully copied')
+
+    if (!response) {
+      res.status(204).send()
+    } else {
+      res.status(201).send()
+    }
   }
 }

--- a/packages/api/src/validators/budget/validate-budget-edit-params.ts
+++ b/packages/api/src/validators/budget/validate-budget-edit-params.ts
@@ -29,7 +29,6 @@ export const validateBudgetEditParams = async ({
     amount: Joi.number().required()
   })
 
-  console.log(body)
   const { error: errorAmount, value: amount } = schemaBody.validate(body)
 
   if (errorAmount) {


### PR DESCRIPTION
- Convert 3 handlers (budgets, edit, copy) from Promise chain with `.then(tap())` to native async/await
- Remove unused imports: `NextFunction`, `extractUser`, `RequestUser`, `tap`
- Remove leftover `console.log` in `validateBudgetEditParams`
- 22/22 tests passing