### PR TITLE
refactor(debts): migrate debt controller to async/await

### DIFF
--- a/packages/api/src/controllers/debt.controller.ts
+++ b/packages/api/src/controllers/debt.controller.ts
@@ -1,11 +1,6 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
-import extractUser from '../helpers/extract-user'
-import { RequestUser } from '../types'
-import { tap } from '../utils/promise'
 import { IDebtService } from '../services/debt.service'
-import { DebtDocument } from '@soker90/finper-models'
 import { validateDebtCreateParams, validateDebtEditParams, validateDebtExist, validateDebtPayParams } from '../validators/debt'
 
 type IDebtController = {
@@ -23,85 +18,63 @@ export class DebtController {
     this.debtService = debtService
   }
 
-  public async create (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.body)
-      .then(tap(({ from }) => this.logger.logInfo(`/create - debt: ${from}`)))
-      .then(extractUser(req))
-      .then(validateDebtCreateParams)
-      .then(this.debtService.addDebt.bind(this.debtService))
-      .then(tap(() => this.logger.logInfo('Debt has been succesfully created')))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async create (req: Request, res: Response): Promise<void> {
+    const { from } = req.body
+    this.logger.logInfo(`/create - debt: ${from}`)
+
+    const params = await validateDebtCreateParams({ ...req.body, user: req.user })
+    const response = await this.debtService.addDebt(params)
+    this.logger.logInfo('Debt has been succesfully created')
+
+    res.send(response)
   }
 
-  public async debts (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.user as string)
-      .then(tap((user: string) => this.logger.logInfo(`/debts - list debts of ${user}`)))
-      .then(this.debtService.getDebts.bind(this.debtService))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async debts (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/debts - list debts of ${req.user}`)
+
+    const response = await this.debtService.getDebts(req.user)
+
+    res.send(response)
   }
 
-  public async debtsFrom (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.params)
-      .then(tap(() => this.logger.logInfo(`/debts - list debts from ${req.params?.from}`)))
-      .then(extractUser(req))
-      .then(this.debtService.getDebtsFrom.bind(this.debtService))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async debtsFrom (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/debts - list debts from ${req.params.from}`)
+
+    const response = await this.debtService.getDebtsFrom({ user: req.user, from: req.params.from })
+
+    res.send(response)
   }
 
-  public async edit (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(({ params }) => this.logger.logInfo(`/edit - debt: ${params?.id}`)))
-      .then(validateDebtEditParams)
-      .then(this.debtService.editDebt.bind(this.debtService))
-      .then(tap(({ _id }: DebtDocument) => this.logger.logInfo(`Debt ${_id} has been succesfully edited`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async edit (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/edit - debt: ${req.params.id}`)
+
+    const { id, value } = await validateDebtEditParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.debtService.editDebt({ id, value })
+    this.logger.logInfo(`Debt ${response._id} has been succesfully edited`)
+
+    res.send(response)
   }
 
-  public async delete (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.params.id)
-      .then(tap((id) => this.logger.logInfo(`/delete - category: ${id}`)))
-      .then(tap(validateDebtExist.bind(null, { id: req.params.id, user: req.user as string })))
-      .then(this.debtService.deleteDebt.bind(this.debtService))
-      .then(() => {
-        res.status(204).send()
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async delete (req: Request, res: Response): Promise<void> {
+    const { id } = req.params
+    this.logger.logInfo(`/delete - debt: ${id}`)
+
+    await validateDebtExist({ id, user: req.user })
+    await this.debtService.deleteDebt(id)
+
+    res.status(204).send()
   }
 
-  public async pay (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(({ params }) => this.logger.logInfo(`/pay - debt: ${params?.id}`)))
-      .then(validateDebtPayParams)
-      .then(this.debtService.payDebt.bind(this.debtService))
-      .then((response) => {
-        if (response === null) {
-          res.status(204).send()
-        } else {
-          res.send(response)
-        }
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async pay (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/pay - debt: ${req.params.id}`)
+
+    const { id, amount } = await validateDebtPayParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.debtService.payDebt({ id, amount })
+
+    if (response === null) {
+      res.status(204).send()
+    } else {
+      res.send(response)
+    }
   }
 }


### PR DESCRIPTION
- Convert 6 handlers (create, debts, debtsFrom, edit, delete, pay) from Promise chain to native async/await
- Remove unused imports: `NextFunction`, `extractUser`, `RequestUser`, `tap`, `DebtDocument`, passport side-effect import
- Fix typo: delete handler log said `/delete - category:` → `/delete - debt:`
- 30/30 tests passing