### PR TITLE
refactor(pension): migrate pension controller to async/await

### DIFF
--- a/packages/api/src/controllers/pension.controller.ts
+++ b/packages/api/src/controllers/pension.controller.ts
@@ -1,10 +1,7 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
 import { IPensionService } from '../services/pension.service'
-import extractUser from '../helpers/extract-user'
 import { validatePensionCreateParams, validatePensionEditParams } from '../validators/pension'
-import { tap } from '../utils/promise'
 
 type IPensionController = {
   loggerHandler: any,
@@ -21,43 +18,31 @@ export class PensionController {
     this.pensionService = pensionService
   }
 
-  public async create (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.body)
-      .then(tap(() => this.logger.logInfo('/create - pension')))
-      .then(validatePensionCreateParams)
-      .then(extractUser(req))
-      .then(this.pensionService.addPension.bind(this.pensionService))
-      .then(tap(({ date }) => this.logger.logInfo(`Pension ${new Date(date).toISOString()} has been succesfully created`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async create (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo('/create - pension')
+
+    const params = await validatePensionCreateParams(req.body)
+    const response = await this.pensionService.addPension({ ...params, user: req.user })
+    this.logger.logInfo(`Pension ${new Date(response.date).toISOString()} has been succesfully created`)
+
+    res.send(response)
   }
 
-  public async edit (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as any)
-      .then(tap(() => this.logger.logInfo('/pensions edit')))
-      .then(validatePensionEditParams)
-      .then(this.pensionService.editPension.bind(this.pensionService))
-      .then(tap(({ date }) => this.logger.logInfo(`Pension ${new Date(date).toISOString()} has been succesfully created`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async edit (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo('/pensions edit')
+
+    const { id, value } = await validatePensionEditParams({ params: { id: req.params.id }, body: req.body, user: req.user })
+    const response = await this.pensionService.editPension({ id, value })
+    this.logger.logInfo(`Pension ${new Date(response.date).toISOString()} has been succesfully edited`)
+
+    res.send(response)
   }
 
-  public async pensions (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.user as string)
-      .then(tap((user: string) => this.logger.logInfo(`/pensions - list pension transactions of ${user}`)))
-      .then(this.pensionService.getPensions.bind(this.pensionService))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async pensions (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/pensions - list pension transactions of ${req.user}`)
+
+    const response = await this.pensionService.getPensions(req.user)
+
+    res.send(response)
   }
 }


### PR DESCRIPTION
- Convert 3 handlers (create, edit, pensions) from Promise chain to native async/await
- Remove unused imports: `NextFunction`, `extractUser`, `tap`, passport side-effect import
- Fix typo: edit handler log said 'created' → 'edited'
- 24/24 tests passing