### PR TITLE
refactor(supply-reading): migrate supply-reading controller to async/await

### DIFF
--- a/packages/api/src/controllers/supply-reading.controller.ts
+++ b/packages/api/src/controllers/supply-reading.controller.ts
@@ -1,7 +1,5 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
-import { SupplyReadingDocument } from '@soker90/finper-models'
 import {
   validateReadingCreateParams,
   validateReadingEditParams,
@@ -9,9 +7,6 @@ import {
 } from '../validators/supply-reading'
 import { validateSupplyExist } from '../validators/supply'
 import { ISupplyReadingService } from '../services/supply-reading.service'
-import extractUser from '../helpers/extract-user'
-import { RequestUser } from '../types'
-import { tap } from '../utils/promise'
 
 type ISupplyReadingController = {
   loggerHandler: any,
@@ -27,60 +22,43 @@ export class SupplyReadingController {
     this.supplyReadingService = supplyReadingService
   }
 
-  public async getReadings (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve({ supplyId: req.params.supplyId })
-      .then(tap(() => this.logger.logInfo(`/supply/${req.params.supplyId} - list readings`)))
-      .then(extractUser(req))
-      .then(tap(({ supplyId, user }) => validateSupplyExist({ id: supplyId as string, user: user as string })))
-      .then(this.supplyReadingService.getSupplyReadings.bind(this.supplyReadingService))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async getReadings (req: Request, res: Response): Promise<void> {
+    const { supplyId } = req.params
+    this.logger.logInfo(`/supply/${supplyId} - list readings`)
+
+    await validateSupplyExist({ id: supplyId, user: req.user })
+    const response = await this.supplyReadingService.getSupplyReadings({ supplyId, user: req.user })
+
+    res.send(response)
   }
 
-  public async create (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.body)
-      .then(tap(() => this.logger.logInfo('/create - supply-reading')))
-      .then(extractUser(req))
-      .then(validateReadingCreateParams)
-      .then(this.supplyReadingService.addReading.bind(this.supplyReadingService))
-      .then(tap(({ _id }: SupplyReadingDocument) => this.logger.logInfo(`Supply Reading ${_id} has been succesfully created`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async create (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo('/create - supply-reading')
+
+    const params = await validateReadingCreateParams({ ...req.body, user: req.user })
+    const response = await this.supplyReadingService.addReading(params)
+    this.logger.logInfo(`Supply Reading ${response._id} has been succesfully created`)
+
+    res.send(response)
   }
 
-  public async edit (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as unknown as RequestUser)
-      .then(tap(() => this.logger.logInfo(`/edit - supply-reading: ${req.params.id}`)))
-      .then(validateReadingEditParams)
-      .then(this.supplyReadingService.editReading.bind(this.supplyReadingService))
-      .then(tap(({ _id }: SupplyReadingDocument) => this.logger.logInfo(`Supply Reading ${_id} has been succesfully edited`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async edit (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/edit - supply-reading: ${req.params.id}`)
+
+    const { id, value } = await validateReadingEditParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.supplyReadingService.editReading({ id, value })
+    this.logger.logInfo(`Supply Reading ${response._id} has been succesfully edited`)
+
+    res.send(response)
   }
 
-  public async delete (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.params as { id: string })
-      .then(tap(({ id }) => this.logger.logInfo(`/delete - supply-reading: ${id}`)))
-      .then(extractUser(req))
-      .then(tap(validateReadingExist))
-      .then(this.supplyReadingService.deleteReading.bind(this.supplyReadingService))
-      .then(() => {
-        res.sendStatus(204)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async delete (req: Request, res: Response): Promise<void> {
+    const { id } = req.params
+    this.logger.logInfo(`/delete - supply-reading: ${id}`)
+
+    await validateReadingExist({ id, user: req.user })
+    await this.supplyReadingService.deleteReading({ id })
+
+    res.sendStatus(204)
   }
 }

--- a/packages/api/src/validators/supply-reading/validate-reading-edit-params.ts
+++ b/packages/api/src/validators/supply-reading/validate-reading-edit-params.ts
@@ -1,19 +1,18 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
 import { ERROR_MESSAGE } from '../../i18n'
-import { RequestUser } from '../../types'
 import { validateReadingExist } from './validate-reading-exist'
 import { validateSupplyExist } from '../supply'
 
-export const validateReadingEditParams = async (data: RequestUser) => {
+export const validateReadingEditParams = async ({ params, body, user }: { params: Record<string, string>, body: Record<string, any>, user: string }) => {
   /* istanbul ignore else — params.id is always present when editing via route (URL param) */
-  if (data.params?.id) {
-    await validateReadingExist({ id: data.params.id, user: data.user as string })
+  if (params.id) {
+    await validateReadingExist({ id: params.id, user })
   }
 
   /* istanbul ignore else — supplyId is always present in the body for edit requests */
-  if (data.body?.supplyId) {
-    await validateSupplyExist({ id: data.body.supplyId as string, user: data.user as string })
+  if (body.supplyId) {
+    await validateSupplyExist({ id: body.supplyId, user })
   }
 
   const schema = Joi.object({
@@ -29,11 +28,11 @@ export const validateReadingEditParams = async (data: RequestUser) => {
     consumptionOffPeak: Joi.number().optional()
   })
 
-  const { error, value } = schema.validate(data.body, { stripUnknown: true })
+  const { error, value } = schema.validate(body, { stripUnknown: true })
 
   if (error) {
     throw Boom.badData(error.message).output
   }
 
-  return { id: data.params?.id, value }
+  return { id: params.id, value }
 }


### PR DESCRIPTION
- Convert 4 handlers (getReadings, create, edit, delete) from Promise chain to native async/await
- Refactor `validateReadingEditParams` to accept `{ params, body, user }` instead of `RequestUser`
- Remove unused imports: `NextFunction`, `extractUser`, `RequestUser`, `tap`, `SupplyReadingDocument`, passport side-effect import
- 16/16 tests passing