### PR TITLE
refactor(property): migrate property controller to async/await

### DIFF
--- a/packages/api/src/controllers/property.controller.ts
+++ b/packages/api/src/controllers/property.controller.ts
@@ -1,16 +1,11 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
-import { PropertyDocument } from '@soker90/finper-models'
 import {
   validatePropertyCreateParams,
   validatePropertyEditParams,
   validatePropertyExist
 } from '../validators/property'
 import { IPropertyService } from '../services/property.service'
-import extractUser from '../helpers/extract-user'
-import { RequestUser } from '../types'
-import { tap } from '../utils/promise'
 
 type IPropertyController = {
   loggerHandler: any,
@@ -26,46 +21,34 @@ export class PropertyController {
     this.propertyService = propertyService
   }
 
-  public async create (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.body)
-      .then(tap(({ name }) => this.logger.logInfo(`/create - property: ${name}`)))
-      .then(extractUser(req))
-      .then(validatePropertyCreateParams)
-      .then(this.propertyService.addProperty.bind(this.propertyService))
-      .then(tap(({ name }: PropertyDocument) => this.logger.logInfo(`Property ${name} has been succesfully created`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async create (req: Request, res: Response): Promise<void> {
+    const { name } = req.body
+    this.logger.logInfo(`/create - property: ${name}`)
+
+    const params = await validatePropertyCreateParams({ ...req.body, user: req.user })
+    const response = await this.propertyService.addProperty(params)
+    this.logger.logInfo(`Property ${response.name} has been succesfully created`)
+
+    res.send(response)
   }
 
-  public async edit (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as unknown as RequestUser)
-      .then(tap(({ body }) => this.logger.logInfo(`/edit - property: ${body.name}`)))
-      .then(validatePropertyEditParams)
-      .then(this.propertyService.editProperty.bind(this.propertyService))
-      .then(tap(({ _id }: PropertyDocument) => this.logger.logInfo(`Property ${_id} has been succesfully edited`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async edit (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/edit - property: ${req.body.name}`)
+
+    const { id, value } = await validatePropertyEditParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.propertyService.editProperty({ id, value })
+    this.logger.logInfo(`Property ${response._id} has been succesfully edited`)
+
+    res.send(response)
   }
 
-  public async delete (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.params as { id: string })
-      .then(tap(({ id }) => this.logger.logInfo(`/delete - property: ${id}`)))
-      .then(extractUser(req))
-      .then(tap(validatePropertyExist))
-      .then(this.propertyService.deleteProperty.bind(this.propertyService))
-      .then(() => {
-        res.sendStatus(204)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async delete (req: Request, res: Response): Promise<void> {
+    const { id } = req.params
+    this.logger.logInfo(`/delete - property: ${id}`)
+
+    await validatePropertyExist({ id, user: req.user })
+    await this.propertyService.deleteProperty({ id })
+
+    res.sendStatus(204)
   }
 }

--- a/packages/api/src/validators/property/validate-property-edit-params.ts
+++ b/packages/api/src/validators/property/validate-property-edit-params.ts
@@ -1,24 +1,23 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
-import { RequestUser } from '../../types'
 import { validatePropertyExist } from './validate-property-exist'
 
-export const validatePropertyEditParams = async (data: RequestUser) => {
+export const validatePropertyEditParams = async ({ params, body, user }: { params: Record<string, string>, body: Record<string, any>, user: string }) => {
   /* istanbul ignore else — params.id is always present when editing via route (URL param) */
-  if (data.params?.id) {
-    await validatePropertyExist({ id: data.params.id, user: data.user as string })
+  if (params.id) {
+    await validatePropertyExist({ id: params.id, user })
   }
 
   const schema = Joi.object({
     name: Joi.string().required()
   })
 
-  const { error, value } = schema.validate(data.body, { stripUnknown: true })
+  const { error, value } = schema.validate(body, { stripUnknown: true })
 
   /* istanbul ignore next — Joi error branch not exercised for property edit in current tests */
   if (error) {
     throw Boom.badData(error.message).output
   }
 
-  return { id: data.params?.id, value }
+  return { id: params.id, value }
 }


### PR DESCRIPTION
- Convert 3 handlers (create, edit, delete) from Promise chain to native async/await
- Refactor `validatePropertyEditParams` to accept `{ params, body, user }` instead of `RequestUser`
- Remove unused imports: `NextFunction`, `extractUser`, `RequestUser`, `tap`, `PropertyDocument`, passport side-effect import
- 9/9 tests passing