### PR TITLE
refactor(goal): migrate goal controller to async/await

### DIFF
--- a/packages/api/src/controllers/goal.controller.ts
+++ b/packages/api/src/controllers/goal.controller.ts
@@ -1,10 +1,5 @@
-import { NextFunction, Request, Response } from 'express'
-import { GoalDocument } from '@soker90/finper-models'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
-import extractUser from '../helpers/extract-user'
-import { RequestUser } from '../types'
-import { tap } from '../utils/promise'
 import { IGoalService } from '../services/goal.service'
 import { validateGoalCreateParams, validateGoalEditParams, validateGoalExist, validateGoalFundParams } from '../validators/goal'
 
@@ -23,99 +18,70 @@ export class GoalController {
     this.goalService = goalService
   }
 
-  public async create (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.body)
-      .then(tap(({ name }) => this.logger.logInfo(`/create - goal: ${name}`)))
-      .then(extractUser(req))
-      .then(validateGoalCreateParams)
-      .then(this.goalService.addGoal.bind(this.goalService))
-      .then(tap(({ name }) => this.logger.logInfo(`Goal ${name} has been successfully created`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async create (req: Request, res: Response): Promise<void> {
+    const { name } = req.body
+    this.logger.logInfo(`/create - goal: ${name}`)
+
+    const params = await validateGoalCreateParams({ ...req.body, user: req.user })
+    const response = await this.goalService.addGoal(params)
+    this.logger.logInfo(`Goal ${response.name} has been successfully created`)
+
+    res.send(response)
   }
 
-  public async goals (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.user as string)
-      .then(tap((user: string) => this.logger.logInfo(`/goals - list goals of ${user}`)))
-      .then(this.goalService.getGoals.bind(this.goalService))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async goals (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/goals - list goals of ${req.user}`)
+
+    const response = await this.goalService.getGoals(req.user)
+
+    res.send(response)
   }
 
-  public async goal (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve({ id: req.params.id })
-      .then(tap(({ id }) => this.logger.logInfo(`/goal - get goal: ${id}`)))
-      .then(extractUser(req))
-      .then(tap(validateGoalExist))
-      .then(({ id, user }) => this.goalService.getGoal({ id, user }))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async goal (req: Request, res: Response): Promise<void> {
+    const { id } = req.params
+    this.logger.logInfo(`/goal - get goal: ${id}`)
+
+    await validateGoalExist({ id, user: req.user })
+    const response = await this.goalService.getGoal({ id, user: req.user })
+
+    res.send(response)
   }
 
-  public async edit (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(({ params }) => this.logger.logInfo(`/edit - goal: ${params?.id}`)))
-      .then(extractUser(req))
-      .then(validateGoalEditParams)
-      .then(this.goalService.editGoal.bind(this.goalService))
-      .then(tap(({ _id }: GoalDocument) => this.logger.logInfo(`Goal ${_id} has been successfully edited`)))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async edit (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/edit - goal: ${req.params.id}`)
+
+    const { id, user, value } = await validateGoalEditParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.goalService.editGoal({ id, user, value })
+    this.logger.logInfo(`Goal ${response._id} has been successfully edited`)
+
+    res.send(response)
   }
 
-  public async delete (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve({ id: req.params.id })
-      .then(tap(({ id }) => this.logger.logInfo(`/delete - goal: ${id}`)))
-      .then(extractUser(req))
-      .then(tap(validateGoalExist))
-      .then(({ id, user }) => this.goalService.deleteGoal({ id, user }))
-      .then(() => {
-        res.status(204).send()
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async delete (req: Request, res: Response): Promise<void> {
+    const { id } = req.params
+    this.logger.logInfo(`/delete - goal: ${id}`)
+
+    await validateGoalExist({ id, user: req.user })
+    await this.goalService.deleteGoal({ id, user: req.user })
+
+    res.status(204).send()
   }
 
-  public async fund (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(({ params }) => this.logger.logInfo(`/fund - goal: ${params?.id}`)))
-      .then(extractUser(req))
-      .then(validateGoalFundParams)
-      .then(this.goalService.fundGoal.bind(this.goalService))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async fund (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/fund - goal: ${req.params.id}`)
+
+    const { id, user, amount } = await validateGoalFundParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.goalService.fundGoal({ id, user, amount })
+
+    res.send(response)
   }
 
-  public async withdraw (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req as RequestUser)
-      .then(tap(({ params }) => this.logger.logInfo(`/withdraw - goal: ${params?.id}`)))
-      .then(extractUser(req))
-      .then(validateGoalFundParams)
-      .then(this.goalService.withdrawGoal.bind(this.goalService))
-      .then((response) => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async withdraw (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/withdraw - goal: ${req.params.id}`)
+
+    const { id, user, amount } = await validateGoalFundParams({ params: req.params, body: req.body, user: req.user })
+    const response = await this.goalService.withdrawGoal({ id, user, amount })
+
+    res.send(response)
   }
 }


### PR DESCRIPTION
- Convert 7 handlers (create, goals, goal, edit, delete, fund, withdraw) from Promise chain to native async/await
- No validator changes needed — `validateGoalEditParams` and `validateGoalFundParams` already accept `{ params, body, user }`
- Remove unused imports: `NextFunction`, `extractUser`, `RequestUser`, `tap`, `GoalDocument`, passport side-effect import
- 33/33 tests passing