### PR TITLE
refactor: migrate stock, store, dashboard, ticket controllers to async/await

### DIFF
--- a/packages/api/src/controllers/dashboard.controller.ts
+++ b/packages/api/src/controllers/dashboard.controller.ts
@@ -1,8 +1,6 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
 import { IDashboardService } from '../services/dashboard'
-import { tap } from '../utils/promise'
 
 type IDashboardController = {
   loggerHandler: any
@@ -18,15 +16,11 @@ export class DashboardController {
     this.dashboardService = dashboardService
   }
 
-  public async stats (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve({ user: req.user as string })
-      .then(tap(() => this.logger.logInfo(`/stats - dashboard stats for ${req.user}`)))
-      .then(this.dashboardService.getStats.bind(this.dashboardService))
-      .then(response => {
-        res.send(response)
-      })
-      .catch((error) => {
-        next(error)
-      })
+  public async stats (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/stats - dashboard stats for ${req.user}`)
+
+    const response = await this.dashboardService.getStats({ user: req.user })
+
+    res.send(response)
   }
 }

--- a/packages/api/src/controllers/stock.controller.ts
+++ b/packages/api/src/controllers/stock.controller.ts
@@ -1,10 +1,7 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
-import '../auth/local-strategy-passport-handler'
 import { IStockService } from '../services/stock.service'
-import extractUser from '../helpers/extract-user'
 import { validateStockCreateParams } from '../validators/stock'
-import { tap } from '../utils/promise'
 
 type IStockController = {
   loggerHandler: any,
@@ -21,51 +18,38 @@ export class StockController {
     this.stockService = stockService
   }
 
-  public async summary (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.user as string)
-      .then(tap((user: string) => this.logger.logInfo(`/stocks/summary - summary of ${user}`)))
-      .then(this.stockService.getStocksSummary.bind(this.stockService))
-      .then(response => { res.send(response) })
-      .catch(error => { next(error) })
+  public async summary (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/stocks/summary - summary of ${req.user}`)
+
+    const response = await this.stockService.getStocksSummary(req.user)
+
+    res.send(response)
   }
 
-  public async stocks (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.user as string)
-      .then(tap((user: string) => this.logger.logInfo(`/stocks - list positions of ${user}`)))
-      .then(this.stockService.getStocks.bind(this.stockService))
-      .then(response => {
-        res.send(response)
-      })
-      .catch(error => {
-        next(error)
-      })
+  public async stocks (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/stocks - list positions of ${req.user}`)
+
+    const response = await this.stockService.getStocks(req.user)
+
+    res.send(response)
   }
 
-  public async create (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.body)
-      .then(tap(() => this.logger.logInfo('/create - stock')))
-      .then(validateStockCreateParams)
-      .then(extractUser(req))
-      .then(this.stockService.addStock.bind(this.stockService))
-      .then(tap(({ ticker }) => this.logger.logInfo(`Stock ${ticker} has been successfully created`)))
-      .then(response => {
-        res.send(response)
-      })
-      .catch(error => {
-        next(error)
-      })
+  public async create (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo('/create - stock')
+
+    const params = await validateStockCreateParams(req.body)
+    const response = await this.stockService.addStock({ ...params, user: req.user })
+    this.logger.logInfo(`Stock ${response.ticker} has been successfully created`)
+
+    res.send(response)
   }
 
-  public async remove (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.params.id)
-      .then(tap(() => this.logger.logInfo('/delete - stock')))
-      .then(id => this.stockService.deleteStock(id, req.user as string))
-      .then(tap(() => this.logger.logInfo('Stock has been successfully deleted')))
-      .then(() => {
-        res.sendStatus(204)
-      })
-      .catch(error => {
-        next(error)
-      })
+  public async remove (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo('/delete - stock')
+
+    await this.stockService.deleteStock(req.params.id, req.user)
+    this.logger.logInfo('Stock has been successfully deleted')
+
+    res.sendStatus(204)
   }
 }

--- a/packages/api/src/controllers/store.controller.ts
+++ b/packages/api/src/controllers/store.controller.ts
@@ -1,9 +1,6 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 
 import { IStoreService } from '../services/stores.service'
-
-import '../auth/local-strategy-passport-handler'
-import { tap } from '../utils/promise'
 
 type IStoreController = {
   loggerHandler: any,
@@ -20,14 +17,11 @@ export class StoreController {
     this.storeService = storeService
   }
 
-  public async stores (req: Request, res: Response, next: NextFunction): Promise<void> {
-    Promise.resolve(req.user as string)
-      .then(tap(() => this.logger.logInfo(`/stores - list stores of ${req.user}`)))
-      .then(this.storeService.getStores.bind(this.storeService))
-      .then(response => {
-        res.send(response)
-      }).catch(error => {
-        next(error)
-      })
+  public async stores (req: Request, res: Response): Promise<void> {
+    this.logger.logInfo(`/stores - list stores of ${req.user}`)
+
+    const response = await this.storeService.getStores(req.user)
+
+    res.send(response)
   }
 }

--- a/packages/api/src/controllers/ticket.controller.ts
+++ b/packages/api/src/controllers/ticket.controller.ts
@@ -1,7 +1,6 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 import { ITicketService } from '../services/ticket.service'
 import { ERROR_MESSAGE } from '../i18n/ErrorMessages'
-import { tap } from '../utils/promise'
 
 type ITicketController = {
   loggerHandler: any
@@ -17,54 +16,45 @@ export class TicketController {
     this.ticketService = ticketService
   }
 
-  public async list (req: Request, res: Response, next: NextFunction): Promise<void> {
+  public async list (req: Request, res: Response): Promise<void> {
     if (!this.ticketService.isConfigured()) {
       res.status(503).json({ message: ERROR_MESSAGE.TICKET.MODULE_NOT_CONFIGURED })
       return
     }
 
     const status = (req.query.status as string) || 'pending'
+    this.logger.logInfo(`/tickets - list tickets status=${status}`)
 
-    Promise.resolve(status)
-      .then(tap(() => this.logger.logInfo(`/tickets - list tickets status=${status}`)))
-      .then(s => this.ticketService.getTickets(s))
-      .then(tickets => {
-        res.send({ tickets, total: tickets.length })
-      })
-      .catch(next)
+    const tickets = await this.ticketService.getTickets(status)
+
+    res.send({ tickets, total: tickets.length })
   }
 
-  public async review (req: Request, res: Response, next: NextFunction): Promise<void> {
+  public async review (req: Request, res: Response): Promise<void> {
     if (!this.ticketService.isConfigured()) {
       res.status(503).json({ message: ERROR_MESSAGE.TICKET.MODULE_NOT_CONFIGURED })
       return
     }
 
     const { id } = req.params
+    this.logger.logInfo(`/tickets/${id} - mark as reviewed`)
 
-    Promise.resolve(id)
-      .then(tap(() => this.logger.logInfo(`/tickets/${id} - mark as reviewed`)))
-      .then(i => this.ticketService.reviewTicket(i))
-      .then(() => {
-        res.status(200).send({ success: true, id })
-      })
-      .catch(next)
+    await this.ticketService.reviewTicket(id)
+
+    res.status(200).send({ success: true, id })
   }
 
-  public async destroy (req: Request, res: Response, next: NextFunction): Promise<void> {
+  public async destroy (req: Request, res: Response): Promise<void> {
     if (!this.ticketService.isConfigured()) {
       res.status(503).json({ message: ERROR_MESSAGE.TICKET.MODULE_NOT_CONFIGURED })
       return
     }
 
     const { id } = req.params
+    this.logger.logInfo(`/tickets/${id} - delete`)
 
-    Promise.resolve(id)
-      .then(tap(() => this.logger.logInfo(`/tickets/${id} - delete`)))
-      .then(i => this.ticketService.deleteTicket(i))
-      .then(() => {
-        res.status(204).send()
-      })
-      .catch(next)
+    await this.ticketService.deleteTicket(id)
+
+    res.status(204).send()
   }
 }


### PR DESCRIPTION
- **stock** (4 handlers): summary, stocks, create, remove
- **store** (1 handler): stores
- **dashboard** (1 handler): stats — `getStats({ user })` explicit object
- **ticket** (3 handlers): list, review, destroy — guard `isConfigured()` preserved
- Remove unused imports from all 4 files
- All tests passing
- **This completes the full controller migration** — no controllers remain using `Promise.resolve`, `extractUser`, or `tap`