### PR TITLE
fix: merge duplicate @soker90/finper-models imports

### DIFF
--- a/packages/api/src/services/dashboard/aggregations.ts
+++ b/packages/api/src/services/dashboard/aggregations.ts
@@ -1,5 +1,4 @@
-import { TRANSACTION } from '@soker90/finper-models'
-import { BudgetModel, TransactionModel } from '@soker90/finper-models'
+import { TRANSACTION, BudgetModel, TransactionModel } from '@soker90/finper-models'
 
 const TIMEZONE = 'Europe/Madrid'
 

--- a/packages/api/src/services/debt.service.ts
+++ b/packages/api/src/services/debt.service.ts
@@ -1,5 +1,4 @@
-import { DEBT } from '@soker90/finper-models'
-import { IDebt, DebtModel, DebtDocument } from '@soker90/finper-models'
+import { DEBT, IDebt, DebtModel, DebtDocument } from '@soker90/finper-models'
 import Boom from '@hapi/boom'
 import { ERROR_MESSAGE } from '../i18n'
 

--- a/packages/api/src/services/loan.service.ts
+++ b/packages/api/src/services/loan.service.ts
@@ -1,6 +1,7 @@
 import type { LoanPaymentType } from '@soker90/finper-types'
-import { LOAN_PAYMENT, TRANSACTION } from '@soker90/finper-models'
 import {
+  LOAN_PAYMENT,
+  TRANSACTION,
   ILoan,
   ILoanPayment,
   ILoanEvent,

--- a/packages/api/src/services/stats.service.ts
+++ b/packages/api/src/services/stats.service.ts
@@ -1,5 +1,4 @@
-import { TRANSACTION } from '@soker90/finper-models'
-import { TransactionModel } from '@soker90/finper-models'
+import { TRANSACTION, TransactionModel } from '@soker90/finper-models'
 import { TagSummary, TagHistoric, TagDetail, TagYearSummary } from '../types/stats.types'
 import { roundNumber } from '../utils/roundNumber'
 

--- a/packages/api/src/services/utils/getTransactionsAmount.ts
+++ b/packages/api/src/services/utils/getTransactionsAmount.ts
@@ -1,5 +1,4 @@
-import { TRANSACTION } from '@soker90/finper-models'
-import { ITransaction } from '@soker90/finper-models'
+import { TRANSACTION, ITransaction } from '@soker90/finper-models'
 
 export const getTransactionAmount = (transaction: ITransaction): number =>
   transaction.type === TRANSACTION.Expense

--- a/packages/api/src/validators/debt/validate-debt-edit-params.ts
+++ b/packages/api/src/validators/debt/validate-debt-edit-params.ts
@@ -1,7 +1,6 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
-import { DEBT } from '@soker90/finper-models'
-import { IDebt } from '@soker90/finper-models'
+import { DEBT, IDebt } from '@soker90/finper-models'
 import { validateDebtExist } from './validate-debt-exist'
 
 export const validateDebtEditParams = async ({

--- a/packages/api/src/validators/stock/validate-stock-create-params.ts
+++ b/packages/api/src/validators/stock/validate-stock-create-params.ts
@@ -1,7 +1,6 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
-import { STOCK_TYPE } from '@soker90/finper-models'
-import { IStock } from '@soker90/finper-models'
+import { STOCK_TYPE, IStock } from '@soker90/finper-models'
 
 export const validateStockCreateParams = async (body: Omit<IStock, 'user'>) => {
   const schema = Joi.object({

--- a/packages/api/src/validators/supply/validate-supply-tariff-comparison.ts
+++ b/packages/api/src/validators/supply/validate-supply-tariff-comparison.ts
@@ -1,6 +1,5 @@
 import Boom from '@hapi/boom'
-import { SUPPLY_TYPE } from '@soker90/finper-models'
-import { SupplyModel } from '@soker90/finper-models'
+import { SUPPLY_TYPE, SupplyModel } from '@soker90/finper-models'
 import { ERROR_MESSAGE } from '../../i18n'
 
 export const validateSupplyForTariffComparison = async ({ id, user }: { id: string, user: string }) => {

--- a/packages/api/src/validators/transaction/validate-transaction-edit-params.ts
+++ b/packages/api/src/validators/transaction/validate-transaction-edit-params.ts
@@ -1,7 +1,6 @@
 import Joi from 'joi'
 import Boom from '@hapi/boom'
-import { TRANSACTION } from '@soker90/finper-models'
-import { ITransaction } from '@soker90/finper-models'
+import { TRANSACTION, ITransaction } from '@soker90/finper-models'
 import { validateTransactionExist } from './validate-transaction-exist'
 
 export const validateTransactionEditParams = async ({


### PR DESCRIPTION
Merge 9 files with duplicate imports from `@soker90/finper-models` into single import statements.

Fixes all 18 `import/no-duplicates` lint warnings. Only the `jest/no-disabled-tests` warning remains (pre-existing skipped test in budget).

Files: `aggregations.ts`, `debt.service.ts`, `loan.service.ts`, `stats.service.ts`, `getTransactionsAmount.ts`, `validate-debt-edit-params.ts`, `validate-stock-create-params.ts`, `validate-supply-tariff-comparison.ts`, `validate-transaction-edit-params.ts`