### PR TITLE
fix: enable strictNullChecks in models and fix vi.mock hoisting in tests

### DIFF
--- a/packages/client/src/pages/Budgets/Budgets.test.tsx
+++ b/packages/client/src/pages/Budgets/Budgets.test.tsx
@@ -5,18 +5,18 @@ import { render } from '../../test/testUtils'
 
 import Budgets from './index'
 
-vi.mock('react-router', async () => {
-  const reactRouterDom = await vi.importActual('react-router')
-  return ({
-    ...reactRouterDom as any,
+vi.mock('react-router', async (importActual) => {
+  const actual = await importActual<typeof import('react-router')>()
+  return {
+    ...actual,
     useParams: vi.fn(() => ({
       year: '2022',
       month: '8'
     }))
-  })
+  }
 })
 
-describe('Budgets', async () => {
+describe('Budgets', () => {
   it('Show title success', async () => {
     const { findByText } = render(<Budgets />)
     const monthLabel = await findByText('Septiembre 2022')

--- a/packages/client/src/pages/Budgets/Budgets.test.tsx
+++ b/packages/client/src/pages/Budgets/Budgets.test.tsx
@@ -1,23 +1,22 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { render } from '../../test/testUtils'
 
 import Budgets from './index'
 
-describe('Budgets', async () => {
-  beforeEach(() => {
-    vi.mock('react-router', async () => {
-      const reactRouterDom = await vi.importActual('react-router')
-      return ({
-        ...reactRouterDom as any,
-        useParams: vi.fn(() => ({
-          year: '2022',
-          month: '8'
-        }))
-      })
-    })
+vi.mock('react-router', async () => {
+  const reactRouterDom = await vi.importActual('react-router')
+  return ({
+    ...reactRouterDom as any,
+    useParams: vi.fn(() => ({
+      year: '2022',
+      month: '8'
+    }))
   })
+})
+
+describe('Budgets', async () => {
   it('Show title success', async () => {
     const { findByText } = render(<Budgets />)
     const monthLabel = await findByText('Septiembre 2022')

--- a/packages/client/src/pages/Login/Login.test.tsx
+++ b/packages/client/src/pages/Login/Login.test.tsx
@@ -8,20 +8,24 @@ import Login from './index'
 import { LOGIN_USERNAMES } from '../../mock/handlers/auth/login'
 
 const user = userEvent.setup()
-let handleSubmit: any
+
+const { handleSubmit } = vi.hoisted(() => ({
+  handleSubmit: vi.fn()
+}))
+
+vi.mock('react-hook-form', () => ({
+  useForm: vi.fn(() => ({
+    register: vi.fn(),
+    handleSubmit,
+    formState: {
+      errors: {}
+    }
+  }))
+}))
 
 describe('Login', async () => {
   beforeEach(() => {
-    handleSubmit = vi.fn()
-    vi.mock('react-hook-form', () => ({
-      useForm: vi.fn(() => ({
-        register: vi.fn(),
-        handleSubmit,
-        formState: {
-          errors: {}
-        }
-      }))
-    }))
+    handleSubmit.mockReset()
   })
 
   it('button login works', async () => {

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -13,7 +13,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "strictNullChecks": false,
     "declaration": true,
     "moduleResolution": "node"
     },


### PR DESCRIPTION
## Cambios

### TypeScript — `packages/models`
- Elimina la línea `"strictNullChecks": false` de `tsconfig.json`, que sobreescribía explícitamente el `strict: true` ya presente.
- Verificado: `tsc --noEmit` pasa sin errores antes y después del cambio.

### Tests — corrección de hoisting de `vi.mock`

#### `Login.test.tsx`
- `vi.mock('react-hook-form', ...)` estaba dentro de `beforeEach`, donde el hoisting de Vitest no funciona.
- Movido al top-level del módulo usando `vi.hoisted()` para la variable `handleSubmit`.
- `beforeEach` ahora llama a `handleSubmit.mockReset()` para aislar los tests.

#### `Budgets.test.tsx`
- Mismo antipatrón: `vi.mock('react-router', ...)` dentro de `beforeEach`.
- Movido al top-level. Se elimina el `beforeEach` vacío resultante.

### Verificación
- `make test-models`: 31/31 tests pasando
- `make test-client`: 212/212 tests pasando (23 suites)