### PR TITLE
fix(client): restore amount colors broken by MUI v9 upgrade

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "1.11.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/pages/Transactions/components/TransactionItem/constans.ts
+++ b/packages/client/src/pages/Transactions/components/TransactionItem/constans.ts
@@ -1,9 +1,9 @@
 import type { TransactionType } from '@soker90/finper-types'
 
 export const AMOUNT_COLORS: Record<TransactionType, string> = {
-  income: 'success.main',
-  expense: 'error.main',
-  not_computable: 'secondary.main'
+  income: 'success',
+  expense: 'error',
+  not_computable: 'secondary'
 }
 
 export const TRANSACTION_SYMBOL: Record<TransactionType, string> = {


### PR DESCRIPTION
## Problema

Al actualizar MUI de v7 a v9 (commit `c76479c`), los importes de la lista de movimientos dejaron de mostrarse en rojo/verde.

## Causa raíz

En MUI v9, el prop `color` de `<Typography>` solo acepta tokens de paleta de **primer nivel** (`'success'`, `'error'`, `'secondary'`). La notación de punto `'success.main'` que se usaba anteriormente ya no se reconoce y devuelve `undefined`, dejando el texto sin color.

MUI v9 resuelve `.main` internamente de forma automática, por lo que el resultado visual es idéntico al anterior.

## Cambios

- `fix(client)`: corregir tokens de color en `AMOUNT_COLORS` — quitar sufijo `.main`
- `chore(client)`: bump versión a `2.0.0`

```diff
- income: 'success.main',
- expense: 'error.main',
- not_computable: 'secondary.main'
+ income: 'success',
+ expense: 'error',
+ not_computable: 'secondary'
```

> `TagTransactionList` no requería cambio: usa `sx={{ color: '...' }}` donde la notación de punto sigue funcionando.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Actualización de la versión principal del cliente a 2.0.0

* **Style**
  * Se actualizaron los tokens de color para los indicadores visuales de transacciones (ingresos, gastos y elementos no calculables), mejorando significativamente la consistencia visual y la alineación con el sistema de diseño y la paleta de temas establecida en la aplicación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->