### PR TITLE
fix(docker): resolve MODULE_NOT_FOUND crash and clarify DATABASE_FILE config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 # ── Base de datos (SQLite) ───────────────────────────────────────────────────
-# Ruta al fichero SQLite. Por defecto en local: ./finper-dev.db
-# En docker-compose se monta en /home/node/app/data/finper.db (volumen persistente).
+# Uso local (sin Docker): ruta relativa al proceso o absoluta.
 DATABASE_FILE=./finper-dev.db
+
+# Uso con Docker Compose: ruta DENTRO del contenedor.
+# El volumen finperdb se monta en /home/node/app/data.
+# El default del compose es /home/node/app/data/finper.db (raíz del volumen).
+# Descomenta y ajusta solo si quieres cambiar el nombre del fichero.
+# DATABASE_FILE=/home/node/app/data/finper.db
 
 # ── Autenticación JWT ────────────────────────────────────────────────────────
 JWT_SECRET=change_this_secret

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,13 +103,12 @@ Copy `.env.example` to `.env` at repo root:
 
 | Variable | Required | Notes |
 |---|---|---|
-| `DATABASE_NAME` | Yes | |
-| `DATABASE_HOST` | Yes | |
-| `JWT_SECRET` | Yes | |
-| `SALT_ROUNDS` | Yes | |
-| `MONGODB` | No | Overrides host+name if set |
-| `MONGODB_USER` / `MONGODB_PASS` | No | |
-| `TICKET_BOT_URL` / `TICKET_BOT_API_KEY` | No | Tickets module |
+| `DATABASE_FILE` | No | SQLite file path. Local default: `./finper-dev.db`. With Docker Compose, the compose sets `/home/node/app/data/finper.db` (volume root) unless overridden here. |
+| `JWT_SECRET` | Yes | JWT signing secret. |
+| `SALT_ROUNDS` | Yes | bcrypt rounds. |
+| `GRAFANA_LOGGER_USER` / `GRAFANA_LOGGER_PASSWORD` | No | External Loki logger. |
+| `LOKI_USER` / `LOKI_PASSWORD` | No | Alias used by the compose files (same credential). |
+| `TICKET_BOT_URL` / `TICKET_BOT_API_KEY` | No | Tickets module integration with `finper-bot`. |
 
 Client also needs `packages/client/.env`:
 ```dotenv

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,11 @@ services:
     container_name: finper-api
     env_file: .env
     environment:
-      DATABASE_FILE: /home/node/app/data/finper.db
+      # Ruta del fichero SQLite DENTRO del contenedor.
+      # El volumen finperdb se monta en /home/node/app/data; el fichero queda
+      # en la raíz de ese volumen. Para cambiar el nombre, sobreescribe
+      # DATABASE_FILE en el .env (ej: DATABASE_FILE=/home/node/app/data/otro.db).
+      DATABASE_FILE: ${DATABASE_FILE:-/home/node/app/data/finper.db}
       JWT_SECRET: ${JWT_SECRET}
       SALT_ROUNDS: ${SALT_ROUNDS}
       LOKI_USER: ${LOKI_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,11 @@ services:
     image: finper-api:latest
     env_file: .env
     environment:
-      DATABASE_FILE: /home/node/app/data/finper.db
+      # Ruta del fichero SQLite DENTRO del contenedor.
+      # El volumen finperdb se monta en /home/node/app/data; el fichero queda
+      # en la raíz de ese volumen. Para cambiar el nombre, sobreescribe
+      # DATABASE_FILE en el .env (ej: DATABASE_FILE=/home/node/app/data/otro.db).
+      DATABASE_FILE: ${DATABASE_FILE:-/home/node/app/data/finper.db}
       JWT_SECRET: ${JWT_SECRET}
       SALT_ROUNDS: ${SALT_ROUNDS}
       LOKI_USER: ${LOKI_USER}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,16 +198,12 @@ Endpoints:
 
 | Variable | Obligatoria | Notas |
 |---|---|---|
-| `DATABASE_NAME` | Sí | |
-| `DATABASE_HOST` | Sí | |
+| `DATABASE_FILE` | No | Ruta al fichero SQLite. Local: `./finper-dev.db`. Docker Compose: el compose usa `/home/node/app/data/finper.db` (raíz del volumen) salvo que se sobreescriba en el `.env`. |
 | `JWT_SECRET` | Sí | Firma JWT. |
 | `SALT_ROUNDS` | Sí | bcrypt. |
-| `MONGODB` | No | URI completa; tiene prioridad sobre host+name. |
-| `MONGODB_USER` / `MONGODB_PASS` | No | |
+| `GRAFANA_LOGGER_USER` / `GRAFANA_LOGGER_PASSWORD` | No | Logger externo Loki. |
+| `LOKI_USER` / `LOKI_PASSWORD` | No | Alias usados por los compose (misma credencial que los anteriores). |
 | `TICKET_BOT_URL` / `TICKET_BOT_API_KEY` | No | Integración con `finper-bot`. |
-| `GRAFANA_LOGGER_USER` / `GRAFANA_LOGGER_PASSWORD` | No | Logger externo (no montado actualmente). |
-
-Específicas de Docker Compose (`docker-compose.yml`): `DATABASE_ROOT_USERNAME`, `DATABASE_ROOT_PASSWORD`, `LOKI_USER`, `LOKI_PASSWORD`.
 
 `packages/client/.env` (consumido por Vite):
 

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine as builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
 
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 
@@ -37,8 +37,6 @@ ENV NPM_CONFIG_LOGLEVEL=info
 ENV NODE_ENV=production
 ENV LOG=1
 ENV TZ=Europe/Madrid
-# Fichero SQLite persistente (montar /home/node/app/data como volumen)
-ENV DATABASE_FILE=/home/node/app/data/finper.db
 
 RUN apk add --no-cache dumb-init
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -56,7 +56,9 @@
     "winston": "3.19.0",
     "winston-loki": "6.1.4",
     "winston-transport": "4.9.0",
-    "yahoo-finance2": "3.14.1"
+    "yahoo-finance2": "3.14.1",
+    "better-sqlite3": "12.10.0",
+    "drizzle-orm": "0.45.2"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",
@@ -79,8 +81,6 @@
     "@typescript-eslint/eslint-plugin": "8.59.3",
     "@typescript-eslint/parser": "8.59.3",
     "babel-jest": "30.4.1",
-    "better-sqlite3": "12.10.0",
-    "drizzle-orm": "0.45.2",
     "eslint": "9.39.2",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import": "2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       bcrypt:
         specifier: 6.0.0
         version: 6.0.0
+      better-sqlite3:
+        specifier: 12.10.0
+        version: 12.10.0
       compression:
         specifier: 1.8.1
         version: 1.8.1
@@ -41,6 +44,9 @@ importers:
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@types/better-sqlite3@7.6.12)(better-sqlite3@12.10.0)(gel@2.2.0)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -141,12 +147,6 @@ importers:
       babel-jest:
         specifier: 30.4.1
         version: 30.4.1(@babel/core@7.29.0)
-      better-sqlite3:
-        specifier: 12.10.0
-        version: 12.10.0
-      drizzle-orm:
-        specifier: 0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@types/better-sqlite3@7.6.12)(better-sqlite3@12.10.0)(gel@2.2.0)
       eslint:
         specifier: 9.39.2
         version: 9.39.2


### PR DESCRIPTION
## Problema

Al arrancar la imagen Docker, el servidor fallaba inmediatamente con:

```
Error: Cannot find module 'drizzle-orm/better-sqlite3/migrator'
```

## Causa

`drizzle-orm` y `better-sqlite3` estaban declarados en `devDependencies` de `packages/api/package.json`, pero `server.ts` los importa en runtime para aplicar las migraciones al arrancar. El stage de producción del Dockerfile ejecuta `pnpm deploy --prod`, que excluye `devDependencies`, dejando los módulos fuera de la imagen.

## Cambios

### Fix crítico
- **`packages/api/package.json`**: mueve `drizzle-orm` y `better-sqlite3` de `devDependencies` a `dependencies`

### Configuración Docker
- **`Dockerfile`**: elimina `ENV DATABASE_FILE` hardcodeada (decisión de deployment, no de imagen); fija pnpm a `10.29.3` en lugar de `@latest` para builds deterministas
- **`docker-compose.yml` / `docker-compose.prod.yml`**: interpola `DATABASE_FILE` desde `.env` con default `${DATABASE_FILE:-/home/node/app/data/finper.db}`, permitiendo cambiar la ruta del fichero SQLite dentro del volumen sin editar el compose

### Documentación
- **`.env.example`**: documenta el uso de `DATABASE_FILE` en local vs Docker
- **`AGENTS.md` / `docs/ARCHITECTURE.md`**: reemplaza la tabla de variables de entorno obsoleta (variables de MongoDB que ya no existen) con las variables actuales de SQLite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Se actualiza la documentación de configuración de entorno y arquitectura con detalles sobre la base de datos.
  * Se clarifica el mapeo de rutas y valores por defecto para diferentes entornos.

* **Chores**
  * Se parametriza la configuración de la base de datos para mayor flexibilidad en despliegues.
  * Se consolida la gestión de variables de entorno entre desarrollo y producción.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->