### PR TITLE
chore: bump all packages to 2.0.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-db",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Database definitions and ORM for finper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-types",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared TypeScript types for finper",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Bump de versión sincronizado en todos los paquetes del monorepo: `2.0.0` → `2.0.1`.

## Paquetes actualizados

- `@soker90/finper-api`
- `@soker90/finper-client`
- `@soker90/finper-db`
- `@soker90/finper-types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Se actualizó la versión de los paquetes a 2.0.1. Se incrementó la versión en todos los módulos del proyecto para mantener la coherencia entre los componentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->