### PR TITLE
fix: corrección del filtrado por tienda en movimientos

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/api/src/modules/transactions/__tests__/transactions.controller.test.ts
+++ b/packages/api/src/modules/transactions/__tests__/transactions.controller.test.ts
@@ -179,6 +179,69 @@ describe('Transactions Controller', () => {
       expect(response.body).toHaveLength(1)
       expect(response.body[0].type).toBe(TRANSACTION.Income)
     })
+
+    test('filters by store when the store query param is provided', async () => {
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`).send(validBody({ store: 'Store A' }))
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`).send(validBody({ store: 'Store B' }))
+
+      const dbStores = sqliteDb.select().from(stores).where(eq(stores.user, username)).all()
+      const storeA = dbStores.find(s => s.name === 'Store A')
+      const storeB = dbStores.find(s => s.name === 'Store B')
+
+      expect(storeA).toBeDefined()
+      expect(storeB).toBeDefined()
+
+      const response = await supertest(server.app).get(`${path}?store=${storeA!.id}`).auth(token, { type: 'bearer' }).expect(200)
+      expect(response.body).toHaveLength(1)
+      expect(response.body[0].store._id).toBe(storeA!.id)
+    })
+
+    test('filters by account when the account query param is provided', async () => {
+      const otherAccount = insertAccount(500)
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`).send(validBody({ account: accountId }))
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`).send(validBody({ account: otherAccount }))
+
+      const response = await supertest(server.app).get(`${path}?account=${otherAccount}`).auth(token, { type: 'bearer' }).expect(200)
+      expect(response.body).toHaveLength(1)
+      expect(response.body[0].account._id).toBe(otherAccount)
+    })
+
+    test('filters by category when the category query param is provided', async () => {
+      const otherCategoryId = generateId()
+      sqliteDb.insert(categories).values({ id: otherCategoryId, name: 'Transport', type: 'expense', user: username }).run()
+
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`).send(validBody({ category: categoryId }))
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`).send(validBody({ category: otherCategoryId }))
+
+      const response = await supertest(server.app).get(`${path}?category=${otherCategoryId}`).auth(token, { type: 'bearer' }).expect(200)
+      expect(response.body).toHaveLength(1)
+      expect(response.body[0].category._id).toBe(otherCategoryId)
+
+      // No se borra otherCategoryId aquí: la transacción que la referencia (FK)
+      // se limpia en el afterEach de este describe, y la propia categoría se
+      // limpia en el afterAll (que borra transactions antes que categories).
+    })
+
+    test('combines store and type filters with AND semantics', async () => {
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`)
+        .send(validBody({ store: 'Combo Store', type: TRANSACTION.Expense }))
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`)
+        .send(validBody({ store: 'Combo Store', type: TRANSACTION.Income }))
+      await supertest(server.app).post(path).set('Authorization', `Bearer ${token}`)
+        .send(validBody({ store: 'Other Store', type: TRANSACTION.Expense }))
+
+      const dbStores = sqliteDb.select().from(stores).where(eq(stores.user, username)).all()
+      const comboStore = dbStores.find(s => s.name === 'Combo Store')
+      expect(comboStore).toBeDefined()
+
+      const response = await supertest(server.app)
+        .get(`${path}?store=${comboStore!.id}&type=${TRANSACTION.Expense}`)
+        .auth(token, { type: 'bearer' }).expect(200)
+
+      expect(response.body).toHaveLength(1)
+      expect(response.body[0].store._id).toBe(comboStore!.id)
+      expect(response.body[0].type).toBe(TRANSACTION.Expense)
+    })
   })
 
   describe('PUT /:id', () => {

--- a/packages/api/src/modules/transactions/transactions.repository.ts
+++ b/packages/api/src/modules/transactions/transactions.repository.ts
@@ -9,6 +9,7 @@ export interface TransactionFilters {
   account?: string
   category?: string
   type?: string
+  store?: string
   page?: number
   limit?: number
 }
@@ -26,11 +27,12 @@ export const createTransactionsRepository = (db: DB) => ({
       .where(and(eq(transactions.id, id), eq(transactions.user, user)))
       .get(),
 
-  findMany: ({ user, account, category, type, page = 0, limit = 50 }: TransactionFilters): TransactionRow[] => {
+  findMany: ({ user, account, category, type, store, page = 0, limit = 50 }: TransactionFilters): TransactionRow[] => {
     const conditions: SQL[] = [eq(transactions.user, user)]
     if (account) conditions.push(eq(transactions.accountId, account))
     if (category) conditions.push(eq(transactions.categoryId, category))
     if (type) conditions.push(eq(transactions.type, type))
+    if (store) conditions.push(eq(transactions.storeId, store))
 
     return db.select({
       id: transactions.id,

--- a/packages/api/src/modules/transactions/transactions.service.ts
+++ b/packages/api/src/modules/transactions/transactions.service.ts
@@ -5,6 +5,7 @@ import { schema, generateId } from '@soker90/finper-db'
 import { getTransactionAmount, sanitizeTags } from '../../utils'
 import { ERROR_MESSAGE } from '../../i18n'
 import { serializeTransaction, serializeTransactionPopulated } from './transactions.serializer'
+import type { TransactionFilters } from './transactions.repository'
 
 const { transactions, accounts } = schema
 
@@ -119,9 +120,7 @@ export class TransactionsService {
     this.hooks.onTransactionDeleted?.(transaction.subscriptionId ?? null)
   }
 
-  public getTransactions (params: {
-    user: string, account?: string, category?: string, type?: string, store?: string, page?: number, limit?: number
-  }): any[] {
+  public getTransactions (params: TransactionFilters): any[] {
     return this.repository.findMany(params).map(serializeTransactionPopulated)
   }
 }

--- a/packages/api/src/modules/transactions/transactions.service.ts
+++ b/packages/api/src/modules/transactions/transactions.service.ts
@@ -120,7 +120,7 @@ export class TransactionsService {
   }
 
   public getTransactions (params: {
-    user: string, account?: string, category?: string, type?: string, page?: number, limit?: number
+    user: string, account?: string, category?: string, type?: string, store?: string, page?: number, limit?: number
   }): any[] {
     return this.repository.findMany(params).map(serializeTransactionPopulated)
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/pages/Transactions/components/TransactionsPage.tsx
+++ b/packages/client/src/pages/Transactions/components/TransactionsPage.tsx
@@ -1,8 +1,9 @@
 import { useTransactions } from '../hooks'
 import TransactionItem from './TransactionItem'
 import { LoadingList } from 'components'
+import { TransactionFilters } from 'types'
 
-export const TransactionsPage = ({ index, filters }: { index: number, filters: any }) => {
+export const TransactionsPage = ({ index, filters }: { index: number, filters: TransactionFilters }) => {
   const { transactions, isLoading, query } = useTransactions({ index, filters })
 
   if (isLoading) {

--- a/packages/client/src/pages/Transactions/components/TransactionsPage.tsx
+++ b/packages/client/src/pages/Transactions/components/TransactionsPage.tsx
@@ -1,9 +1,14 @@
-import { useTransactions } from '../hooks'
+import { useTransactions } from '../hooks/useTransactions'
 import TransactionItem from './TransactionItem'
 import { LoadingList } from 'components'
 import { TransactionFilters } from 'types'
 
-export const TransactionsPage = ({ index, filters }: { index: number, filters: TransactionFilters }) => {
+interface TransactionsPageProps {
+  index: number,
+  filters: TransactionFilters,
+}
+
+export const TransactionsPage = ({ index, filters }: TransactionsPageProps) => {
   const { transactions, isLoading, query } = useTransactions({ index, filters })
 
   if (isLoading) {

--- a/packages/client/src/pages/Transactions/hooks/useFilters.test.tsx
+++ b/packages/client/src/pages/Transactions/hooks/useFilters.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useFilters } from './useFilters'
+
+const EMPTY_FILTERS = {
+  category: '',
+  type: '',
+  account: '',
+  store: ''
+}
+
+describe('useFilters', () => {
+  it('starts with all filter values set to an empty string', () => {
+    const { result } = renderHook(() => useFilters())
+
+    expect(result.current.filters).toEqual(EMPTY_FILTERS)
+  })
+
+  it('updates only the given key when calling setFilter', () => {
+    const { result } = renderHook(() => useFilters())
+
+    act(() => result.current.setFilter('account', 'acc-1'))
+
+    expect(result.current.filters).toEqual({ ...EMPTY_FILTERS, account: 'acc-1' })
+  })
+
+  it('keeps previously set filters when setting a different key', () => {
+    const { result } = renderHook(() => useFilters())
+
+    act(() => result.current.setFilter('account', 'acc-1'))
+    act(() => result.current.setFilter('store', 'store-1'))
+
+    expect(result.current.filters).toEqual({
+      ...EMPTY_FILTERS,
+      account: 'acc-1',
+      store: 'store-1'
+    })
+  })
+
+  it('restores all filters to an empty string when calling resetFilter', () => {
+    const { result } = renderHook(() => useFilters())
+
+    act(() => result.current.setFilter('category', 'cat-1'))
+    act(() => result.current.resetFilter())
+
+    expect(result.current.filters).toEqual(EMPTY_FILTERS)
+  })
+})

--- a/packages/client/src/pages/Transactions/hooks/useFilters.ts
+++ b/packages/client/src/pages/Transactions/hooks/useFilters.ts
@@ -3,11 +3,9 @@ import { TransactionFilters } from 'types'
 
 type FilterKey = keyof TransactionFilters
 
-interface FilterAction {
-  type: 'set' | 'reset';
-  key?: FilterKey;
-  value?: string
-}
+type FilterAction =
+  | { type: 'set', key: FilterKey, value: string }
+  | { type: 'reset' }
 
 export interface FilterParams {
   setFilter: (key: FilterKey, value: string) => void,
@@ -22,13 +20,15 @@ const emptyFilters: TransactionFilters = {
   store: ''
 }
 
-const filtersReducer = (state: TransactionFilters, { type, key, value }: FilterAction): TransactionFilters => ({
-  set: { ...state, [key as FilterKey]: value },
-  reset: emptyFilters
-}[type])
+const filtersReducer = (state: TransactionFilters, action: FilterAction): TransactionFilters => {
+  if (action.type === 'set') {
+    return { ...state, [action.key]: action.value }
+  }
+  return emptyFilters
+}
 
 export const useFilters = (): FilterParams => {
-  const [filters, setFilters] = useReducer(filtersReducer, {})
+  const [filters, setFilters] = useReducer(filtersReducer, emptyFilters)
 
   const setFilter = (key: FilterKey, value: string) => setFilters({ type: 'set', key, value })
   const resetFilter = () => setFilters({ type: 'reset' })

--- a/packages/client/src/pages/Transactions/hooks/useFilters.ts
+++ b/packages/client/src/pages/Transactions/hooks/useFilters.ts
@@ -1,31 +1,36 @@
 import { useReducer } from 'react'
+import { TransactionFilters } from 'types'
+
+type FilterKey = keyof TransactionFilters
 
 interface FilterAction {
   type: 'set' | 'reset';
-  key?: string;
+  key?: FilterKey;
   value?: string
 }
 
 export interface FilterParams {
-  setFilter: (key: string, value: string) => void,
+  setFilter: (key: FilterKey, value: string) => void,
   resetFilter: () => void,
-  filters: any,
+  filters: TransactionFilters,
 }
 
-export const useFilters = (): FilterParams => {
-  const [filters, setFilters] = useReducer(
-    (state: any, { type, key, value }: FilterAction) => ({
-      set: { ...state, [key as string]: value },
-      reset: {
-        category: '',
-        type: '',
-        account: '',
-        store: ''
-      }
-    }[type]),
-    {})
+const emptyFilters: TransactionFilters = {
+  category: '',
+  type: '',
+  account: '',
+  store: ''
+}
 
-  const setFilter = (key: string, value: string) => setFilters({ type: 'set', key, value })
+const filtersReducer = (state: TransactionFilters, { type, key, value }: FilterAction): TransactionFilters => ({
+  set: { ...state, [key as FilterKey]: value },
+  reset: emptyFilters
+}[type])
+
+export const useFilters = (): FilterParams => {
+  const [filters, setFilters] = useReducer(filtersReducer, {})
+
+  const setFilter = (key: FilterKey, value: string) => setFilters({ type: 'set', key, value })
   const resetFilter = () => setFilters({ type: 'reset' })
 
   return { setFilter, resetFilter, filters }

--- a/packages/client/src/pages/Transactions/hooks/useTransactions.ts
+++ b/packages/client/src/pages/Transactions/hooks/useTransactions.ts
@@ -1,11 +1,11 @@
 import useSWR from 'swr'
 import { TRANSACTIONS } from 'constants/api-paths'
-import { Transaction } from 'types'
+import { Transaction, TransactionFilters } from 'types'
 import { objectToParams } from 'utils/objectToParams'
 
 interface UseTransactions {
   index: number,
-  filters: any,
+  filters: TransactionFilters,
 }
 
 export const useTransactions = ({

--- a/packages/client/src/types/transaction.ts
+++ b/packages/client/src/types/transaction.ts
@@ -20,3 +20,14 @@ export interface Transaction {
   },
   tags?: string[],
 }
+
+// Filtros aceptados por GET /transactions (ver TransactionFilters en
+// packages/api/src/modules/transactions/transactions.repository.ts). Los
+// valores son siempre el _id de la entidad seleccionada (o '' si no hay
+// filtro activo), nunca el objeto completo.
+export interface TransactionFilters {
+  account?: string,
+  category?: string,
+  type?: string,
+  store?: string,
+}

--- a/packages/client/src/types/transaction.ts
+++ b/packages/client/src/types/transaction.ts
@@ -21,10 +21,10 @@ export interface Transaction {
   tags?: string[],
 }
 
-// Filtros aceptados por GET /transactions (ver TransactionFilters en
-// packages/api/src/modules/transactions/transactions.repository.ts). Los
-// valores son siempre el _id de la entidad seleccionada (o '' si no hay
-// filtro activo), nunca el objeto completo.
+// Filters accepted by GET /transactions (see TransactionFilters in
+// packages/api/src/modules/transactions/transactions.repository.ts). The
+// values are always the _id of the selected entity (or '' when there is no
+// active filter), never the full object.
 export interface TransactionFilters {
   account?: string,
   category?: string,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-db",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Database definitions and ORM for finper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-types",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared TypeScript types for finper",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Corrige el filtrado por tienda en la consulta de movimientos. El parámetro 'store' (comercio/tienda) recibido en el endpoint de transacciones ahora se mapea a 'transactions.storeId' y se aplica como condición en el repositorio. Adicionalmente, se añadió una prueba de integración unitaria en el controlador de transacciones para verificar su correcto funcionamiento.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Se añadió el filtro por **tienda** en la lista de transacciones.
  * Ahora se pueden combinar varios filtros a la vez, incluyendo tienda, cuenta, categoría y tipo.

* **Pruebas**
  * Se ampliaron las pruebas para validar el filtrado por parámetros de búsqueda y su comportamiento conjunto.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->