### PR TITLE
fix(api): implement graceful shutdown to checkpoint SQLite WAL journal

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,9 @@ services:
       LOKI_PASSWORD: ${LOKI_PASSWORD}
       TICKET_BOT_URL: ${TICKET_BOT_URL}
       TICKET_BOT_API_KEY: ${TICKET_BOT_API_KEY}
+    # Da margen al graceful shutdown (checkpoint del WAL de SQLite, ver
+    # server.ts SHUTDOWN_TIMEOUT_MS) antes de que Docker mande SIGKILL.
+    stop_grace_period: 15s
     volumes:
       - finperdb:/home/node/app/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     build:
       context: .
       dockerfile: ./packages/api/Dockerfile
+    # Da margen al graceful shutdown (checkpoint del WAL de SQLite, ver
+    # server.ts SHUTDOWN_TIMEOUT_MS) antes de que Docker mande SIGKILL.
+    stop_grace_period: 15s
     volumes:
       - finperdb:/home/node/app/data
     ports:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -66,6 +66,7 @@
     "@faker-js/faker": "10.4.0",
     "@tsconfig/node22": "22.0.5",
     "@types/bcrypt": "6.0.0",
+    "@types/better-sqlite3": "7.6.12",
     "@types/compression": "1.8.1",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/api/src/__tests__/server.test.ts
+++ b/packages/api/src/__tests__/server.test.ts
@@ -1,0 +1,75 @@
+import { checkpointAndCloseDatabase } from '../server'
+
+type SqliteConnection = Parameters<typeof checkpointAndCloseDatabase>[0]
+
+const buildMockClient = (overrides: Partial<SqliteConnection> = {}): SqliteConnection => ({
+  open: true,
+  pragma: jest.fn().mockReturnValue([{ busy: 0, log: 10, checkpointed: 10 }]),
+  close: jest.fn(),
+  ...overrides
+} as unknown as SqliteConnection)
+
+describe('checkpointAndCloseDatabase', () => {
+  it('runs a WAL checkpoint and closes the connection on success', () => {
+    const client = buildMockClient()
+
+    const exitCode = checkpointAndCloseDatabase(client)
+
+    expect(client.pragma).toHaveBeenCalledWith('wal_checkpoint(TRUNCATE)')
+    expect(client.close).toHaveBeenCalledTimes(1)
+    expect(exitCode).toBe(0)
+  })
+
+  it('skips the checkpoint entirely when the connection is already closed', () => {
+    const client = buildMockClient({ open: false })
+
+    const exitCode = checkpointAndCloseDatabase(client)
+
+    expect(client.pragma).not.toHaveBeenCalled()
+    expect(client.close).not.toHaveBeenCalled()
+    expect(exitCode).toBe(0)
+  })
+
+  it('still exits with code 0 when the checkpoint could not fully truncate the WAL (busy)', () => {
+    const client = buildMockClient({
+      pragma: jest.fn().mockReturnValue([{ busy: 1, log: 10, checkpointed: 4 }])
+    })
+
+    const exitCode = checkpointAndCloseDatabase(client)
+
+    expect(client.close).toHaveBeenCalledTimes(1)
+    expect(exitCode).toBe(0)
+  })
+
+  it('closes the connection and exits with code 1 when the checkpoint pragma throws', () => {
+    const client = buildMockClient({
+      pragma: jest.fn().mockImplementation(() => { throw new Error('disk I/O error') })
+    })
+
+    const exitCode = checkpointAndCloseDatabase(client)
+
+    expect(client.close).toHaveBeenCalledTimes(1)
+    expect(exitCode).toBe(1)
+  })
+
+  it('exits with code 1 when closing the connection throws, even if the checkpoint succeeded', () => {
+    const client = buildMockClient({
+      close: jest.fn().mockImplementation(() => { throw new Error('database is locked') })
+    })
+
+    const exitCode = checkpointAndCloseDatabase(client)
+
+    expect(exitCode).toBe(1)
+  })
+
+  it('exits with code 1 when both the checkpoint and the close fail', () => {
+    const client = buildMockClient({
+      pragma: jest.fn().mockImplementation(() => { throw new Error('disk I/O error') }),
+      close: jest.fn().mockImplementation(() => { throw new Error('database is locked') })
+    })
+
+    const exitCode = checkpointAndCloseDatabase(client)
+
+    expect(exitCode).toBe(1)
+  })
+})

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -114,3 +114,22 @@ export const server = new Server()
 if (process.env.NODE_ENV !== 'test') {
   server.start()
 }
+
+const gracefulShutdown = () => {
+  console.log('\n[finper-api] Received shutdown signal, starting graceful shutdown...')
+  try {
+    const sqliteClient = (sqliteDb as any).$client
+    if (sqliteClient) {
+      console.log('[finper-api] Consolidating WAL journal to database file...')
+      sqliteClient.pragma('wal_checkpoint(TRUNCATE)')
+      sqliteClient.close()
+      console.log('[finper-api] SQLite database closed and WAL checkpoint completed successfully.')
+    }
+  } catch (error) {
+    console.error('[finper-api] Error during database graceful shutdown checkpoint:', error)
+  }
+  process.exit(0)
+}
+
+process.on('SIGTERM', gracefulShutdown)
+process.on('SIGINT', gracefulShutdown)

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -33,6 +33,7 @@ import { statsRoutes } from './modules/stats/stats.routes'
 
 class Server {
   public app: express.Application
+  public httpServer: import('node:http').Server | null = null
 
   constructor () {
     this.app = express()
@@ -102,7 +103,7 @@ class Server {
 
   /* istanbul ignore next — start() is only called outside of test env */
   public start (): void {
-    this.app.listen(this.app.get('port'), () => {
+    this.httpServer = this.app.listen(this.app.get('port'), () => {
       console.log(`API is running at http://localhost:${this.app.get('port')}`)
     })
   }
@@ -115,8 +116,7 @@ if (process.env.NODE_ENV !== 'test') {
   server.start()
 }
 
-const gracefulShutdown = () => {
-  console.log('\n[finper-api] Received shutdown signal, starting graceful shutdown...')
+const closeDatabase = () => {
   try {
     const sqliteClient = (sqliteDb as any).$client
     if (sqliteClient) {
@@ -129,6 +129,30 @@ const gracefulShutdown = () => {
     console.error('[finper-api] Error during database graceful shutdown checkpoint:', error)
   }
   process.exit(0)
+}
+
+const gracefulShutdown = () => {
+  console.log('\n[finper-api] Received shutdown signal, starting graceful shutdown...')
+
+  // Force exit after 10 seconds if graceful shutdown hangs (e.g. keep-alive connections)
+  setTimeout(() => {
+    console.error('[finper-api] Graceful shutdown timed out, forcing exit.')
+    process.exit(1)
+  }, 10000).unref()
+
+  if (server.httpServer) {
+    console.log('[finper-api] Closing HTTP server...')
+    server.httpServer.close((httpCloseError) => {
+      if (httpCloseError) {
+        console.error('[finper-api] Error closing HTTP server:', httpCloseError)
+      } else {
+        console.log('[finper-api] HTTP server closed.')
+      }
+      closeDatabase()
+    })
+  } else {
+    closeDatabase()
+  }
 }
 
 process.on('SIGTERM', gracefulShutdown)

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -38,6 +38,14 @@ interface WalCheckpointResult {
   checkpointed: number
 }
 
+interface ShutdownOptions {
+  reason: string
+  // Skips waiting for the HTTP server to drain in-flight requests. Must be
+  // used for uncaughtException/unhandledRejection, where the process state
+  // may be corrupted and should not keep serving traffic.
+  immediate?: boolean
+}
+
 const SHUTDOWN_TIMEOUT_MS = 8_000
 
 /**
@@ -162,7 +170,7 @@ class Server {
   }
 
   /* istanbul ignore next — only invoked on SIGTERM/SIGINT/uncaught errors */
-  public shutdown (reason: string): void {
+  public shutdown ({ reason, immediate = false }: ShutdownOptions): void {
     if (this.isShuttingDown) {
       console.log('[finper-api] Shutdown already in progress, ignoring duplicate trigger.')
       return
@@ -180,19 +188,26 @@ class Server {
       process.exit(checkpointAndCloseDatabase(sqliteDb.$client))
     }
 
-    if (this.httpServer) {
-      console.log('[finper-api] Closing HTTP server...')
-      // Drop idle keep-alive sockets immediately; in-flight requests are
-      // still allowed to finish before the close() callback below fires.
-      this.httpServer.closeIdleConnections()
-      this.httpServer.close((closeError) => {
-        if (closeError) console.error('[finper-api] Error closing HTTP server:', closeError)
-        else console.log('[finper-api] HTTP server closed.')
-        closeDatabaseAndExit()
-      })
-    } else {
+    // Node.js explicitly warns against resuming normal operation after
+    // 'uncaughtException'/'unhandledRejection': the process state may be
+    // corrupted. In that case we skip waiting for in-flight HTTP requests to
+    // finish (which would keep serving traffic on a potentially broken
+    // state) and go straight to the SQLite checkpoint before exiting.
+    if (immediate || !this.httpServer) {
+      if (immediate) console.log('[finper-api] Fatal error detected, skipping graceful HTTP close.')
       closeDatabaseAndExit()
+      return
     }
+
+    console.log('[finper-api] Closing HTTP server...')
+    // Drop idle keep-alive sockets immediately; in-flight requests are
+    // still allowed to finish before the close() callback below fires.
+    this.httpServer.closeIdleConnections()
+    this.httpServer.close((closeError) => {
+      if (closeError) console.error('[finper-api] Error closing HTTP server:', closeError)
+      else console.log('[finper-api] HTTP server closed.')
+      closeDatabaseAndExit()
+    })
   }
 }
 
@@ -202,16 +217,16 @@ export const server = new Server()
 if (process.env.NODE_ENV !== 'test') {
   server.start()
 
-  process.on('SIGTERM', () => server.shutdown('SIGTERM'))
-  process.on('SIGINT', () => server.shutdown('SIGINT'))
+  process.on('SIGTERM', () => server.shutdown({ reason: 'SIGTERM' }))
+  process.on('SIGINT', () => server.shutdown({ reason: 'SIGINT' }))
 
   process.on('uncaughtException', (error) => {
     console.error('[finper-api] Uncaught exception:', error)
-    server.shutdown('uncaughtException')
+    server.shutdown({ reason: 'uncaughtException', immediate: true })
   })
 
   process.on('unhandledRejection', (reason) => {
     console.error('[finper-api] Unhandled promise rejection:', reason)
-    server.shutdown('unhandledRejection')
+    server.shutdown({ reason: 'unhandledRejection', immediate: true })
   })
 }

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config'
 import express from 'express'
+import type { Database as SqliteConnection } from 'better-sqlite3'
 
 import cors from 'cors'
 import compression from 'compression'
@@ -31,9 +32,61 @@ import { stocksRouter } from './modules/stocks/stocks.routes'
 import { goalsRouter } from './modules/goals/goals.routes'
 import { statsRoutes } from './modules/stats/stats.routes'
 
+interface WalCheckpointResult {
+  busy: number
+  log: number
+  checkpointed: number
+}
+
+const SHUTDOWN_TIMEOUT_MS = 8_000
+
+/**
+ * Consolidates the WAL journal into the main database file and closes the
+ * SQLite connection. Extracted as a standalone function (instead of inline
+ * inside Server.shutdown) so it can be unit tested by injecting a fake
+ * better-sqlite3 client, without needing to simulate OS signals or spin up
+ * an HTTP server.
+ *
+ * Returns the process exit code that should be used: 0 on success, 1 if the
+ * checkpoint or the close itself failed.
+ */
+export function checkpointAndCloseDatabase (sqliteClient: SqliteConnection): number {
+  if (!sqliteClient.open) {
+    console.log('[finper-api] SQLite connection already closed, skipping checkpoint.')
+    return 0
+  }
+
+  let exitCode = 0
+
+  try {
+    console.log('[finper-api] Consolidating WAL journal to database file...')
+    const [{ busy, log, checkpointed }] = sqliteClient.pragma('wal_checkpoint(TRUNCATE)') as WalCheckpointResult[]
+
+    if (busy) {
+      console.warn(`[finper-api] WAL checkpoint could not fully complete (busy=${busy}, checkpointed=${checkpointed}/${log} pages).`)
+    } else {
+      console.log(`[finper-api] WAL journal consolidated successfully (${checkpointed}/${log} pages).`)
+    }
+  } catch (error) {
+    console.error('[finper-api] Error during database checkpoint:', error)
+    exitCode = 1
+  } finally {
+    try {
+      sqliteClient.close()
+      console.log('[finper-api] SQLite database closed.')
+    } catch (error) {
+      console.error('[finper-api] Error closing SQLite database:', error)
+      exitCode = 1
+    }
+  }
+
+  return exitCode
+}
+
 class Server {
   public app: express.Application
   public httpServer: import('node:http').Server | null = null
+  private isShuttingDown = false
 
   constructor () {
     this.app = express()
@@ -108,32 +161,30 @@ class Server {
     })
   }
 
-  /* istanbul ignore next — only invoked on SIGTERM/SIGINT */
-  public shutdown (): void {
-    console.log('\n[finper-api] Received shutdown signal, starting graceful shutdown...')
+  /* istanbul ignore next — only invoked on SIGTERM/SIGINT/uncaught errors */
+  public shutdown (reason: string): void {
+    if (this.isShuttingDown) {
+      console.log('[finper-api] Shutdown already in progress, ignoring duplicate trigger.')
+      return
+    }
+    this.isShuttingDown = true
+
+    console.log(`\n[finper-api] Received ${reason}, starting graceful shutdown...`)
 
     setTimeout(() => {
       console.error('[finper-api] Graceful shutdown timed out, forcing exit.')
       process.exit(1)
-    }, 10_000).unref()
+    }, SHUTDOWN_TIMEOUT_MS).unref()
 
     const closeDatabaseAndExit = () => {
-      try {
-        const sqliteClient = (sqliteDb as any).$client
-        if (sqliteClient) {
-          console.log('[finper-api] Consolidating WAL journal to database file...')
-          sqliteClient.pragma('wal_checkpoint(TRUNCATE)')
-          sqliteClient.close()
-          console.log('[finper-api] SQLite database closed successfully.')
-        }
-      } catch (error) {
-        console.error('[finper-api] Error during database checkpoint:', error)
-      }
-      process.exit(0)
+      process.exit(checkpointAndCloseDatabase(sqliteDb.$client))
     }
 
     if (this.httpServer) {
       console.log('[finper-api] Closing HTTP server...')
+      // Drop idle keep-alive sockets immediately; in-flight requests are
+      // still allowed to finish before the close() callback below fires.
+      this.httpServer.closeIdleConnections()
       this.httpServer.close((closeError) => {
         if (closeError) console.error('[finper-api] Error closing HTTP server:', closeError)
         else console.log('[finper-api] HTTP server closed.')
@@ -147,10 +198,20 @@ class Server {
 
 export const server = new Server()
 
-/* istanbul ignore next — server.start() is skipped in test env */
+/* istanbul ignore next — server.start() and process-level handlers are skipped in test env */
 if (process.env.NODE_ENV !== 'test') {
   server.start()
-}
 
-process.on('SIGTERM', server.shutdown.bind(server))
-process.on('SIGINT', server.shutdown.bind(server))
+  process.on('SIGTERM', () => server.shutdown('SIGTERM'))
+  process.on('SIGINT', () => server.shutdown('SIGINT'))
+
+  process.on('uncaughtException', (error) => {
+    console.error('[finper-api] Uncaught exception:', error)
+    server.shutdown('uncaughtException')
+  })
+
+  process.on('unhandledRejection', (reason) => {
+    console.error('[finper-api] Unhandled promise rejection:', reason)
+    server.shutdown('unhandledRejection')
+  })
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -107,6 +107,42 @@ class Server {
       console.log(`API is running at http://localhost:${this.app.get('port')}`)
     })
   }
+
+  /* istanbul ignore next — only invoked on SIGTERM/SIGINT */
+  public shutdown (): void {
+    console.log('\n[finper-api] Received shutdown signal, starting graceful shutdown...')
+
+    setTimeout(() => {
+      console.error('[finper-api] Graceful shutdown timed out, forcing exit.')
+      process.exit(1)
+    }, 10_000).unref()
+
+    const closeDatabaseAndExit = () => {
+      try {
+        const sqliteClient = (sqliteDb as any).$client
+        if (sqliteClient) {
+          console.log('[finper-api] Consolidating WAL journal to database file...')
+          sqliteClient.pragma('wal_checkpoint(TRUNCATE)')
+          sqliteClient.close()
+          console.log('[finper-api] SQLite database closed successfully.')
+        }
+      } catch (error) {
+        console.error('[finper-api] Error during database checkpoint:', error)
+      }
+      process.exit(0)
+    }
+
+    if (this.httpServer) {
+      console.log('[finper-api] Closing HTTP server...')
+      this.httpServer.close((closeError) => {
+        if (closeError) console.error('[finper-api] Error closing HTTP server:', closeError)
+        else console.log('[finper-api] HTTP server closed.')
+        closeDatabaseAndExit()
+      })
+    } else {
+      closeDatabaseAndExit()
+    }
+  }
 }
 
 export const server = new Server()
@@ -116,44 +152,5 @@ if (process.env.NODE_ENV !== 'test') {
   server.start()
 }
 
-const closeDatabase = () => {
-  try {
-    const sqliteClient = (sqliteDb as any).$client
-    if (sqliteClient) {
-      console.log('[finper-api] Consolidating WAL journal to database file...')
-      sqliteClient.pragma('wal_checkpoint(TRUNCATE)')
-      sqliteClient.close()
-      console.log('[finper-api] SQLite database closed and WAL checkpoint completed successfully.')
-    }
-  } catch (error) {
-    console.error('[finper-api] Error during database graceful shutdown checkpoint:', error)
-  }
-  process.exit(0)
-}
-
-const gracefulShutdown = () => {
-  console.log('\n[finper-api] Received shutdown signal, starting graceful shutdown...')
-
-  // Force exit after 10 seconds if graceful shutdown hangs (e.g. keep-alive connections)
-  setTimeout(() => {
-    console.error('[finper-api] Graceful shutdown timed out, forcing exit.')
-    process.exit(1)
-  }, 10000).unref()
-
-  if (server.httpServer) {
-    console.log('[finper-api] Closing HTTP server...')
-    server.httpServer.close((httpCloseError) => {
-      if (httpCloseError) {
-        console.error('[finper-api] Error closing HTTP server:', httpCloseError)
-      } else {
-        console.log('[finper-api] HTTP server closed.')
-      }
-      closeDatabase()
-    })
-  } else {
-    closeDatabase()
-  }
-}
-
-process.on('SIGTERM', gracefulShutdown)
-process.on('SIGINT', gracefulShutdown)
+process.on('SIGTERM', server.shutdown.bind(server))
+process.on('SIGINT', server.shutdown.bind(server))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@types/bcrypt':
         specifier: 6.0.0
         version: 6.0.0
+      '@types/better-sqlite3':
+        specifier: 7.6.12
+        version: 7.6.12
       '@types/compression':
         specifier: 1.8.1
         version: 1.8.1


### PR DESCRIPTION
This PR introduces graceful shutdown handlers for SIGTERM and SIGINT to checkpoint the SQLite WAL journal. This ensures that any pending transactions in the WAL file are cleanly consolidated into the main database file when the Docker container stops, preventing data loss and keeping the host file synchronized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funciones**
  * Se mejoró el apagado del servicio al recibir señales, realizando un cierre “graceful” y asegurando un checkpoint de SQLite antes de finalizar.
  * Se agregó lógica para controlar tiempos de espera y registrar el resultado del cierre.
* **Mejoras de configuración**
  * Se configuró `stop_grace_period: 15s` en la ejecución con Docker para dar margen al checkpoint antes de la detención forzada.
* **Tests**
  * Se incorporaron pruebas para validar el comportamiento del cierre y los códigos de salida según escenarios de error y conexión ya cerrada.
* **Chores**
  * Se incrementó la versión del paquete y se añadieron tipos para una dependencia.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->