### PR TITLE
ci(bot): add lint, type-check and auto-deploy to Cloudflare Workers

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -247,3 +247,70 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           flags: client
+
+  ## Bot ##
+  changes-bot:
+    runs-on: ubuntu-latest
+    outputs:
+      bot: ${{ steps.filter.outputs.bot }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            bot:
+              - 'packages/bot/**'
+
+  lint-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v7
+        with:
+          cache: 'pnpm'
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @soker90/finper-bot
+      - name: Lint
+        run: make lint-bot
+
+  type-check-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v7
+        with:
+          cache: 'pnpm'
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @soker90/finper-bot
+      - name: Type check
+        run: make type-check-bot
+
+  deploy-bot:
+    needs: [ changes-bot, lint-bot, type-check-bot ]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && needs.changes-bot.outputs.bot == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v7
+        with:
+          cache: 'pnpm'
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @soker90/finper-bot
+      - name: Deploy
+        run: make deploy-bot
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+permissions:
+  contents: read
+
 jobs:
   ## Types ##
   build-types:

--- a/packages/bot/wrangler.toml
+++ b/packages/bot/wrangler.toml
@@ -3,6 +3,9 @@ main = "src/index.ts"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 
+[placement]
+mode = "smart"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "ticket-bot-db"


### PR DESCRIPTION
## Resumen

Añade CI/CD para el paquete `bot` (Telegram bot en Cloudflare Workers):

- **`lint-bot`** y **`type-check-bot`**: se ejecutan en cada push/PR, igual que el resto de paquetes.
- **`deploy-bot`**: despliega automáticamente con `wrangler deploy` al hacer push a `master`, pero **solo si hubo cambios en `packages/bot/**`** (detectado con `dorny/paths-filter`). No se ejecuta en PRs, solo tras el merge.
- Requiere los secrets `CLOUDFLARE_API_TOKEN` y `CLOUDFLARE_ACCOUNT_ID` en el repo (ya configurados).

También restaura `placement.mode = "smart"` en `wrangler.toml`, que se había perdido en un deploy manual anterior que sobrescribió la config remota del dashboard con la local (que no lo tenía versionado).

## Verificación
- Confirmado que el bot no depende de `types`/`db` vía workspace, por lo que `lint-bot`/`type-check-bot` pueden instalar solo con `--filter @soker90/finper-bot`.
- YAML validado con `python3 -c \"import yaml; yaml.safe_load(...)\"`.
- Deploy manual de prueba (`wrangler deploy --dry-run` y deploy real) confirmó que los bindings D1/R2 y la nueva config de `placement` se aplican correctamente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Se incorporó un flujo automatizado para validar cambios del bot mediante lint y comprobaciones de tipos.
  * El despliegue del bot se ejecuta automáticamente en la rama principal cuando las validaciones son satisfactorias y se detectan cambios relevantes.
  * Se añadió configuración para optimizar automáticamente la ubicación del servicio del bot.

* **Mantenimiento**
  * Se integraron credenciales seguras para el despliegue en Cloudflare.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->