### PR TITLE
ci: restrict GITHUB_TOKEN permissions in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Resumen

Añade un bloque `permissions: contents: read` a nivel de workflow en `docker.yml`.

## Motivo

Al revisar el hallazgo de CodeQL (`actions/missing-workflow-permissions`) detectado en la PR #859 sobre `pipeline.yml`, se identificó que `docker.yml` tiene el mismo gap: no declara `permissions`, por lo que el `GITHUB_TOKEN` hereda el scope por defecto del repositorio (potencialmente read-write).

El job `docker` solo hace `checkout` del repo y publica imágenes en DockerHub usando sus propias credenciales (`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`), nunca escribe en GitHub. Por tanto `contents: read` es suficiente y sigue el principio de menor privilegio.

## Verificación
- YAML validado con `python3 -c \"import yaml; yaml.safe_load(...)\"`.
- No se modifica la lógica del job, solo se restringe el scope del token.