### PR TITLE
fix(client): purge invalid JWT tokens and prevent infinite loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-08-04
+
+### Fixed
+
+- **client**: Purge invalid or malformed JWT tokens (`"undefined"`, `"null"`, empty strings) from `localStorage` automatically, prevent `jwtDecode` runtime crashes, and resolve infinite loading state on `<SplashScreen />` when initializing offline or after request errors. ([#871](https://github.com/soker90/finper/pull/871))
+
 ---
 
 ## [2.1.0] - 2026-07-18

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/components/Auth/Auth.test.tsx
+++ b/packages/client/src/components/Auth/Auth.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+
+import Auth from './index'
+
+const { handleLogout, setAccessToken } = vi.hoisted(() => ({
+  handleLogout: vi.fn(),
+  setAccessToken: vi.fn()
+}))
+
+vi.mock('hooks/useAuth', () => ({
+  default: () => ({ handleLogout, setAccessToken, hasToken: () => false })
+}))
+
+const authServiceMock = vi.hoisted(() => ({
+  setAxiosInterceptors: vi.fn(),
+  handleAuthentication: vi.fn(),
+  isAuthenticated: vi.fn(),
+  loginInWithToken: vi.fn(),
+  getAccessToken: vi.fn(),
+  isValidToken: vi.fn(),
+  logout: vi.fn()
+}))
+
+vi.mock('services/authService', () => ({ default: authServiceMock }))
+
+const renderAuth = () => render(
+  <MemoryRouter>
+    <Auth>
+      <div>protected content</div>
+    </Auth>
+  </MemoryRouter>
+)
+
+describe('Auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders children and stores the refreshed token when authentication succeeds', async () => {
+    authServiceMock.isAuthenticated.mockReturnValue(true)
+    authServiceMock.loginInWithToken.mockResolvedValue('valid-token')
+
+    renderAuth()
+
+    await screen.findByText('protected content')
+    expect(setAccessToken).toHaveBeenCalledWith('valid-token')
+    expect(authServiceMock.logout).not.toHaveBeenCalled()
+    expect(handleLogout).not.toHaveBeenCalled()
+  })
+
+  it('logs out when the user is not authenticated', async () => {
+    authServiceMock.isAuthenticated.mockReturnValue(false)
+
+    renderAuth()
+
+    await screen.findByText('protected content')
+
+    expect(authServiceMock.logout).toHaveBeenCalledTimes(1)
+    expect(handleLogout).toHaveBeenCalledTimes(1)
+    expect(setAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('logs out when refreshing the token fails with a 401 error', async () => {
+    authServiceMock.isAuthenticated.mockReturnValue(true)
+    authServiceMock.loginInWithToken.mockRejectedValue({ statusCode: 401 })
+
+    renderAuth()
+
+    await screen.findByText('protected content')
+
+    expect(authServiceMock.logout).toHaveBeenCalledTimes(1)
+    expect(handleLogout).toHaveBeenCalledTimes(1)
+    expect(setAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('keeps the session using the locally stored token when the refresh fails for a non-401 reason', async () => {
+    authServiceMock.isAuthenticated.mockReturnValue(true)
+    authServiceMock.loginInWithToken.mockRejectedValue(new Error('Network Error'))
+    authServiceMock.getAccessToken.mockReturnValue('local-token')
+    authServiceMock.isValidToken.mockReturnValue(true)
+
+    renderAuth()
+
+    await screen.findByText('protected content')
+
+    expect(setAccessToken).toHaveBeenCalledWith('local-token')
+    expect(authServiceMock.logout).not.toHaveBeenCalled()
+    expect(handleLogout).not.toHaveBeenCalled()
+  })
+
+  it('logs out when the refresh fails for a non-401 reason and there is no valid local token', async () => {
+    authServiceMock.isAuthenticated.mockReturnValue(true)
+    authServiceMock.loginInWithToken.mockRejectedValue(new Error('Network Error'))
+    authServiceMock.getAccessToken.mockReturnValue(null)
+
+    renderAuth()
+
+    await screen.findByText('protected content')
+
+    expect(authServiceMock.logout).toHaveBeenCalledTimes(1)
+    expect(handleLogout).toHaveBeenCalledTimes(1)
+    expect(setAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('logs out and does not crash when initialization throws unexpectedly', async () => {
+    authServiceMock.setAxiosInterceptors.mockImplementation(() => {
+      throw new Error('unexpected failure')
+    })
+
+    renderAuth()
+
+    await screen.findByText('protected content')
+
+    expect(authServiceMock.logout).toHaveBeenCalledTimes(1)
+    expect(handleLogout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/client/src/components/Auth/index.tsx
+++ b/packages/client/src/components/Auth/index.tsx
@@ -59,9 +59,9 @@ const Auth = ({ children }: { children: any }): JSX.Element => {
       } catch (error) {
         console.error('Failed to initialize authentication:', error)
         forceLogout()
-      } finally {
-        setInitialized(true)
       }
+
+      setInitialized(true)
     }
 
     initAuth()

--- a/packages/client/src/components/Auth/index.tsx
+++ b/packages/client/src/components/Auth/index.tsx
@@ -5,29 +5,63 @@ import SplashScreen from 'components/SplashScreen'
 import authService from 'services/authService'
 import useAuth from 'hooks/useAuth'
 
+const isUnauthorizedError = (error: unknown): boolean => {
+  const { status, statusCode } = (error ?? {}) as { status?: number, statusCode?: number }
+  return status === 401 || statusCode === 401
+}
+
 const Auth = ({ children }: { children: any }): JSX.Element => {
   const [isInitialized, setInitialized] = useState(false)
   const { handleLogout, setAccessToken } = useAuth()
   const navigate = useNavigate()
 
   useEffect(() => {
-    const initAuth = async () => {
-      authService.setAxiosInterceptors({
-        onLogout: () => {
-          handleLogout()
-          navigate('/login')
-        }
-      })
+    const forceLogout = () => {
+      authService.logout()
+      handleLogout()
+    }
 
-      authService.handleAuthentication()
-
-      if (authService.isAuthenticated()) {
+    const refreshSessionToken = async () => {
+      try {
         const token = await authService.loginInWithToken()
         setAccessToken(token)
-        // initialize dashboard
-      }
+      } catch (authError) {
+        if (isUnauthorizedError(authError)) {
+          forceLogout()
+          return
+        }
 
-      setInitialized(true)
+        const currentToken = authService.getAccessToken()
+        if (currentToken && authService.isValidToken(currentToken)) {
+          setAccessToken(currentToken)
+        } else {
+          forceLogout()
+        }
+      }
+    }
+
+    const initAuth = async () => {
+      try {
+        authService.setAxiosInterceptors({
+          onLogout: () => {
+            handleLogout()
+            navigate('/login')
+          }
+        })
+
+        authService.handleAuthentication()
+
+        if (authService.isAuthenticated()) {
+          await refreshSessionToken()
+        } else {
+          forceLogout()
+        }
+      } catch (error) {
+        console.error('Failed to initialize authentication:', error)
+        forceLogout()
+      } finally {
+        setInitialized(true)
+      }
     }
 
     initAuth()

--- a/packages/client/src/components/Auth/index.tsx
+++ b/packages/client/src/components/Auth/index.tsx
@@ -1,4 +1,4 @@
-import { type JSX, useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import SplashScreen from 'components/SplashScreen'
@@ -10,7 +10,7 @@ const isUnauthorizedError = (error: unknown): boolean => {
   return status === 401 || statusCode === 401
 }
 
-const Auth = ({ children }: { children: any }): JSX.Element => {
+const Auth = ({ children }: { children: ReactNode }): ReactNode => {
   const [isInitialized, setInitialized] = useState(false)
   const { handleLogout, setAccessToken } = useAuth()
   const navigate = useNavigate()

--- a/packages/client/src/services/authService.test.ts
+++ b/packages/client/src/services/authService.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { FINPER_TOKEN } from 'config'
+import authService from './authService'
+
+describe('authService token management', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should return null and purge localStorage when token is "undefined"', () => {
+    localStorage.setItem(FINPER_TOKEN, 'undefined')
+
+    const accessToken = authService.getAccessToken()
+
+    expect(accessToken).toBeNull()
+    expect(localStorage.getItem(FINPER_TOKEN)).toBeNull()
+  })
+
+  it('should return null and purge localStorage when token is "null"', () => {
+    localStorage.setItem(FINPER_TOKEN, 'null')
+
+    const accessToken = authService.getAccessToken()
+
+    expect(accessToken).toBeNull()
+    expect(localStorage.getItem(FINPER_TOKEN)).toBeNull()
+  })
+
+  it('should return false safely in isValidToken for malformed token string without crashing', () => {
+    expect(authService.isValidToken('invalid-jwt-string')).toBe(false)
+    expect(authService.isValidToken('undefined')).toBe(false)
+    expect(authService.isValidToken('')).toBe(false)
+  })
+
+  it('should validate non-expired valid JWT tokens', () => {
+    const futureExpiryInSeconds = Math.floor(Date.now() / 1000) + 3600
+    const mockPayload = JSON.stringify({ exp: futureExpiryInSeconds, username: 'testuser' })
+    const base64Payload = btoa(mockPayload)
+    const validJwtToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${base64Payload}.mockSignature`
+
+    expect(authService.isValidToken(validJwtToken)).toBe(true)
+  })
+
+  it('should invalidate expired JWT tokens', () => {
+    const pastExpiryInSeconds = Math.floor(Date.now() / 1000) - 3600
+    const mockPayload = JSON.stringify({ exp: pastExpiryInSeconds, username: 'testuser' })
+    const base64Payload = btoa(mockPayload)
+    const expiredJwtToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${base64Payload}.mockSignature`
+
+    expect(authService.isValidToken(expiredJwtToken)).toBe(false)
+  })
+
+  it('should clear session when setSession is called with null', () => {
+    localStorage.setItem(FINPER_TOKEN, 'some-token')
+
+    authService.setSession(null)
+
+    expect(localStorage.getItem(FINPER_TOKEN)).toBeNull()
+    expect(authService.isAuthenticated()).toBe(false)
+  })
+})

--- a/packages/client/src/services/authService.ts
+++ b/packages/client/src/services/authService.ts
@@ -3,6 +3,19 @@ import axios from 'axios'
 import { FINPER_TOKEN } from 'config'
 import { isTokenPresent } from 'utils/isTokenPresent'
 
+const decodeToken = (accessToken: string): { exp?: number } | null => {
+  try {
+    return jwtDecode(accessToken)
+  } catch {
+    return null
+  }
+}
+
+const clearStoredSession = () => {
+  localStorage.removeItem(FINPER_TOKEN)
+  delete axios.defaults.headers.common.Authorization
+}
+
 class AuthService {
   setAxiosInterceptors = ({ onLogout }: { onLogout: () => void }) => {
     axios.interceptors.response.use(
@@ -10,8 +23,7 @@ class AuthService {
       error => {
         if (error.response && error.response.status === 401) {
           this.setSession(null)
-
-          if (onLogout) onLogout()
+          onLogout()
         }
 
         return Promise.reject(error)
@@ -42,8 +54,8 @@ class AuthService {
           resolve(data.token)
         } else reject(data.error)
       })
-      .catch(({ response }) => {
-        reject(response.data)
+      .catch(error => {
+        reject(error?.response?.data || error)
       })
   })
 
@@ -76,16 +88,14 @@ class AuthService {
       localStorage.setItem(FINPER_TOKEN, accessToken)
       axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`
     } else {
-      localStorage.removeItem(FINPER_TOKEN)
-      delete axios.defaults.headers.common.Authorization
+      clearStoredSession()
     }
   }
 
   getAccessToken = (): string | null => {
     const storedToken = localStorage.getItem(FINPER_TOKEN)
     if (!isTokenPresent(storedToken)) {
-      localStorage.removeItem(FINPER_TOKEN)
-      delete axios.defaults.headers.common.Authorization
+      clearStoredSession()
       return null
     }
     return storedToken
@@ -94,26 +104,11 @@ class AuthService {
   isValidToken = (accessToken: string | null): boolean => {
     if (!isTokenPresent(accessToken)) return false
 
-    try {
-      const decodedToken: { exp?: number } = jwtDecode(accessToken)
-      if (!decodedToken || typeof decodedToken.exp !== 'number') return false
+    const decodedToken = decodeToken(accessToken)
+    if (!decodedToken || typeof decodedToken.exp !== 'number') return false
 
-      const currentTimeInSeconds = Date.now() / 1000
-      return decodedToken.exp > currentTimeInSeconds
-    } catch {
-      return false
-    }
-  }
-
-  getExpireToken = (accessToken: string | null): number => {
-    if (!isTokenPresent(accessToken)) return 0
-
-    try {
-      const decodedToken: { exp?: number } = jwtDecode(accessToken)
-      return decodedToken.exp || 0
-    } catch {
-      return 0
-    }
+    const currentTimeInSeconds = Date.now() / 1000
+    return decodedToken.exp > currentTimeInSeconds
   }
 
   isAuthenticated = (): boolean => {

--- a/packages/client/src/services/authService.ts
+++ b/packages/client/src/services/authService.ts
@@ -1,6 +1,7 @@
 import { jwtDecode } from 'jwt-decode'
 import axios from 'axios'
 import { FINPER_TOKEN } from 'config'
+import { isTokenPresent } from 'utils/isTokenPresent'
 
 class AuthService {
   setAxiosInterceptors = ({ onLogout }: { onLogout: () => void }) => {
@@ -18,13 +19,19 @@ class AuthService {
     )
   }
 
-  handleAuthentication () {
+  handleAuthentication = (): void => {
     const accessToken = this.getAccessToken()
 
-    if (!accessToken) return
+    if (!accessToken) {
+      this.setSession(null)
+      return
+    }
 
-    if (this.isValidToken(accessToken)) this.setSession(accessToken)
-    else this.setSession(null)
+    if (this.isValidToken(accessToken)) {
+      this.setSession(accessToken)
+    } else {
+      this.setSession(null)
+    }
   }
 
   loginWithUsernameAndPassword = (username: string, password: string) => new Promise<string>((resolve, reject) => {
@@ -43,14 +50,20 @@ class AuthService {
   loginInWithToken = (): Promise<string> => new Promise((resolve, reject) => {
     axios.get('/auth/me')
       .then(({ headers }) => {
-        if (headers.token) {
+        if (isTokenPresent(headers.token)) {
           this.setSession(headers.token)
           resolve(headers.token)
-        } else throw new Error()
+        } else {
+          const currentToken = this.getAccessToken()
+          if (currentToken) {
+            resolve(currentToken)
+          } else {
+            reject(new Error('No token available'))
+          }
+        }
       })
-      .catch(({ response }) => {
-        console.log('error', response)
-        reject(response.data)
+      .catch(error => {
+        reject(error?.response?.data || error)
       })
   })
 
@@ -59,7 +72,7 @@ class AuthService {
   }
 
   setSession = (accessToken: string | null) => {
-    if (accessToken) {
+    if (isTokenPresent(accessToken)) {
       localStorage.setItem(FINPER_TOKEN, accessToken)
       axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`
     } else {
@@ -68,26 +81,45 @@ class AuthService {
     }
   }
 
-  getAccessToken = (): string => localStorage.getItem(FINPER_TOKEN) as string
-
-  isValidToken = (accessToken: string) => {
-    if (!accessToken) return false
-
-    const decoded: any = jwtDecode(accessToken)
-    const currentTime = Date.now() / 1000
-
-    return decoded.exp > currentTime
+  getAccessToken = (): string | null => {
+    const storedToken = localStorage.getItem(FINPER_TOKEN)
+    if (!isTokenPresent(storedToken)) {
+      localStorage.removeItem(FINPER_TOKEN)
+      delete axios.defaults.headers.common.Authorization
+      return null
+    }
+    return storedToken
   }
 
-  getExpireToken = (accessToken: string): number => {
-    if (!accessToken) return 0
+  isValidToken = (accessToken: string | null): boolean => {
+    if (!isTokenPresent(accessToken)) return false
 
-    const decoded: any = jwtDecode(accessToken)
+    try {
+      const decodedToken: { exp?: number } = jwtDecode(accessToken)
+      if (!decodedToken || typeof decodedToken.exp !== 'number') return false
 
-    return decoded.exp
+      const currentTimeInSeconds = Date.now() / 1000
+      return decodedToken.exp > currentTimeInSeconds
+    } catch {
+      return false
+    }
   }
 
-  isAuthenticated = () => !!this.getAccessToken()
+  getExpireToken = (accessToken: string | null): number => {
+    if (!isTokenPresent(accessToken)) return 0
+
+    try {
+      const decodedToken: { exp?: number } = jwtDecode(accessToken)
+      return decodedToken.exp || 0
+    } catch {
+      return 0
+    }
+  }
+
+  isAuthenticated = (): boolean => {
+    const accessToken = this.getAccessToken()
+    return Boolean(accessToken && this.isValidToken(accessToken))
+  }
 }
 
 const authService = new AuthService()

--- a/packages/client/src/utils/axios.ts
+++ b/packages/client/src/utils/axios.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { API_HOST, FINPER_TOKEN } from 'config'
+import { isTokenPresent } from 'utils/isTokenPresent'
 
 // ========================================================
 // Axios config
@@ -8,8 +9,10 @@ axios.defaults.baseURL = API_HOST
 axios.interceptors.response.use(
   response => {
     const { token } = response.headers
-    localStorage.setItem(FINPER_TOKEN, token as string)
-    axios.defaults.headers.common.Authorization = `Bearer ${token}`
+    if (isTokenPresent(token)) {
+      localStorage.setItem(FINPER_TOKEN, token)
+      axios.defaults.headers.common.Authorization = `Bearer ${token}`
+    }
     return response
   }
 )

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './objectToParams'
 export const capitalize = (word: string) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`
 export * from './getPreviousMonthYear'
 export { sanitizeTag } from './sanitizeTag'
+export { isTokenPresent } from './isTokenPresent'

--- a/packages/client/src/utils/isTokenPresent.ts
+++ b/packages/client/src/utils/isTokenPresent.ts
@@ -1,0 +1,8 @@
+/**
+ * Guards against tokens that are missing or have been serialized as the
+ * literal strings "undefined"/"null" (e.g. via `` `Bearer ${token}` `` when
+ * `token` was actually `undefined`), which would otherwise be persisted as
+ * valid-looking values in localStorage/headers.
+ */
+export const isTokenPresent = (token?: string | null): token is string =>
+  Boolean(token) && token !== 'undefined' && token !== 'null' && (token as string).trim() !== ''

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-db",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Database definitions and ORM for finper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-types",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Shared TypeScript types for finper",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
Fixes an issue where invalid or unparsed JWT tokens (such as "undefined" or "null" strings stored in `localStorage`) caused `jwtDecode` runtime crashes or stuck the application infinitely on the `<SplashScreen />` loading state (e.g., when starting offline or after request errors).

## Changes Included
- **`utils/isTokenPresent.ts`**: Added helper function `isTokenPresent` to guard against missing or literal string tokens (`"undefined"`, `"null"`, whitespace).
- **`utils/axios.ts`**: Updated Axios response interceptor to check `isTokenPresent` before persisting tokens to `localStorage` and setting `Authorization` headers.
- **`services/authService.ts`**: 
  - `getAccessToken()` purges `localStorage` automatically when token value is missing or invalid according to `isTokenPresent`.
  - `isValidToken()` safely handles `jwtDecode` errors inside a `try...catch` block.
  - `handleAuthentication()` and `isAuthenticated()` strictly validate token presence and expiration.
- **`components/Auth/index.tsx`**:
  - Wrapped `initAuth` initialization in a `try...catch...finally` block ensuring `setInitialized(true)` is always called so the loading screen never freezes.
  - Gracefully preserves local session for offline usage when token is non-expired, while logging out on explicit `401 Unauthorized` responses.
- **Unit Tests**:
  - `services/authService.test.ts`: Unit tests for `isTokenPresent`, token purging, and safe decoding.
  - `components/Auth/Auth.test.tsx`: Tests for initialization, token refresh, 401 handling, and offline fallbacks.

## Verification
- Executed `make test-client`: All 28 test suites passed (269 tests).
- Executed `make lint-client`: 0 linter warnings/errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras**
  * Se mejoró la gestión de autenticación y renovación de sesiones.
  * Se validan correctamente tokens ausentes, inválidos, expirados o vacíos.
  * Se evita guardar tokens no válidos y se refuerza el cierre de sesión ante errores de autorización.

* **Pruebas**
  * Se añadieron pruebas para autenticación, cierre de sesión, recuperación mediante token y errores inesperados.
  * Se incorporaron pruebas de validación, expiración y limpieza de tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->