### PR TITLE
feat(bot, api): link Telegram users to Finper accounts for ticket filtering

### DIFF
--- a/packages/api/src/modules/ticket/ticket.controller.ts
+++ b/packages/api/src/modules/ticket/ticket.controller.ts
@@ -23,9 +23,10 @@ export class TicketController {
     }
 
     const status = (req.query.status as string) || 'pending'
+    const finperUsername = req.user as string
     this.logger.logInfo(`/tickets - list tickets status=${status}`)
 
-    const tickets = await this.ticketService.getTickets(status)
+    const tickets = await this.ticketService.getTickets(status, finperUsername)
 
     res.send({ tickets, total: tickets.length })
   }

--- a/packages/api/src/modules/ticket/ticket.service.ts
+++ b/packages/api/src/modules/ticket/ticket.service.ts
@@ -2,6 +2,7 @@ export interface Ticket {
   id: string
   telegram_message_id: number
   telegram_chat_id: number
+  telegram_user_id: number | null
   image_url: string | null
   date: number | null
   store: string | null
@@ -15,7 +16,7 @@ export interface Ticket {
 
 export interface ITicketService {
   isConfigured(): boolean
-  getTickets(status?: string): Promise<Ticket[]>
+  getTickets(status: string, finperUsername: string): Promise<Ticket[]>
   reviewTicket(id: string): Promise<void>
   deleteTicket(id: string): Promise<void>
 }
@@ -42,8 +43,10 @@ export default class TicketService implements ITicketService {
     }
   }
 
-  public async getTickets (status: string = 'pending'): Promise<Ticket[]> {
-    const res = await fetch(`${this.botUrl}/api/tickets?status=${status}`, {
+  public async getTickets (status: string = 'pending', finperUsername: string): Promise<Ticket[]> {
+    const params = new URLSearchParams({ status, finper_username: finperUsername })
+
+    const res = await fetch(`${this.botUrl}/api/tickets?${params.toString()}`, {
       headers: this.headers()
     })
 

--- a/packages/bot/schema.sql
+++ b/packages/bot/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS tickets (
   id TEXT PRIMARY KEY,
   telegram_message_id INTEGER NOT NULL,
   telegram_chat_id INTEGER NOT NULL,
+  telegram_user_id INTEGER,                -- Telegram user ID of the sender (nullable for legacy rows)
   image_url TEXT,                          -- nullable: text-sourced tickets have no image
   -- Data extracted by Gemini
   date INTEGER,                            -- Unix timestamp (ms) extracted from ticket
@@ -20,10 +21,12 @@ CREATE TABLE IF NOT EXISTS tickets (
 
 CREATE INDEX IF NOT EXISTS idx_tickets_status ON tickets(status);
 CREATE INDEX IF NOT EXISTS idx_tickets_created_at ON tickets(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tickets_telegram_user_id ON tickets(telegram_user_id);
 
 -- Users allowed to send tickets to the bot (managed by the admin via bot commands)
 CREATE TABLE IF NOT EXISTS allowed_users (
-  user_id   INTEGER PRIMARY KEY,  -- Telegram user ID
-  added_by  INTEGER NOT NULL,      -- Telegram user ID of the admin who added them
-  added_at  INTEGER NOT NULL       -- Unix timestamp (ms)
+  user_id         INTEGER PRIMARY KEY,  -- Telegram user ID
+  added_by        INTEGER NOT NULL,     -- Telegram user ID of the admin who added them
+  added_at        INTEGER NOT NULL,     -- Unix timestamp (ms)
+  finper_username TEXT                  -- Finper username this Telegram user is linked to (several telegram_user_id can share the same finper_username)
 );

--- a/packages/bot/src/db/tickets.ts
+++ b/packages/bot/src/db/tickets.ts
@@ -5,12 +5,13 @@ export async function insertTicket (
   ticket: Omit<Ticket, 'status' | 'reviewed_at'>
 ): Promise<void> {
   await db.prepare(`
-    INSERT INTO tickets (id, telegram_message_id, telegram_chat_id, image_url, date, store, amount, raw_text, payment_method, status, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+    INSERT INTO tickets (id, telegram_message_id, telegram_chat_id, telegram_user_id, image_url, date, store, amount, raw_text, payment_method, status, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
   `).bind(
     ticket.id,
     ticket.telegram_message_id,
     ticket.telegram_chat_id,
+    ticket.telegram_user_id,
     ticket.image_url,
     ticket.date,
     ticket.store,
@@ -23,31 +24,23 @@ export async function insertTicket (
 
 export async function getTickets (
   db: D1Database,
-  status: 'pending' | 'reviewed' | 'all' = 'pending'
+  status: 'pending' | 'reviewed' | 'all' = 'pending',
+  finperUsername: string
 ): Promise<Ticket[]> {
-  let query = 'SELECT * FROM tickets'
-  const params: string[] = []
+  const conditions: string[] = [
+    'telegram_user_id IN (SELECT user_id FROM allowed_users WHERE finper_username = ?)'
+  ]
+  const params: (string | number)[] = [finperUsername]
 
   if (status !== 'all') {
-    query += ' WHERE status = ?'
+    conditions.push('status = ?')
     params.push(status)
   }
 
-  query += ' ORDER BY created_at DESC'
+  const query = `SELECT * FROM tickets WHERE ${conditions.join(' AND ')} ORDER BY created_at DESC`
 
   const result = await db.prepare(query).bind(...params).all<Ticket>()
   return result.results
-}
-
-export async function markTicketReviewed (
-  db: D1Database,
-  id: string
-): Promise<boolean> {
-  const result = await db.prepare(`
-    UPDATE tickets SET status = 'reviewed', reviewed_at = ? WHERE id = ? AND status = 'pending'
-  `).bind(Date.now(), id).run()
-
-  return (result.meta.changes ?? 0) > 0
 }
 
 export async function getTicketById (

--- a/packages/bot/src/db/users.ts
+++ b/packages/bot/src/db/users.ts
@@ -2,6 +2,7 @@ export interface AllowedUser {
   user_id: number
   added_by: number
   added_at: number
+  finper_username: string | null
 }
 
 /**
@@ -18,17 +19,20 @@ export async function isUserAllowed (db: D1Database, userId: number): Promise<bo
 }
 
 /**
- * Adds a user to the allowed list. Returns false if the user was already present.
+ * Adds a user to the allowed list, linked to a Finper username. Several Telegram
+ * users can be linked to the same Finper username. Returns false if the user
+ * was already present.
  */
 export async function addAllowedUser (
   db: D1Database,
   userId: number,
-  addedBy: number
+  addedBy: number,
+  finperUsername: string
 ): Promise<boolean> {
   try {
     await db
-      .prepare('INSERT INTO allowed_users (user_id, added_by, added_at) VALUES (?, ?, ?)')
-      .bind(userId, addedBy, Date.now())
+      .prepare('INSERT INTO allowed_users (user_id, added_by, added_at, finper_username) VALUES (?, ?, ?, ?)')
+      .bind(userId, addedBy, Date.now(), finperUsername)
       .run()
     return true
   } catch {
@@ -56,7 +60,22 @@ export async function removeAllowedUser (
  */
 export async function listAllowedUsers (db: D1Database): Promise<AllowedUser[]> {
   const result = await db
-    .prepare('SELECT user_id, added_by, added_at FROM allowed_users ORDER BY added_at ASC')
+    .prepare('SELECT user_id, added_by, added_at, finper_username FROM allowed_users ORDER BY added_at ASC')
     .all<AllowedUser>()
   return result.results
+}
+
+/**
+ * Returns the Telegram user IDs linked to the given Finper username.
+ * Used to filter tickets by the currently authenticated Finper user.
+ */
+export async function listTelegramUserIdsByFinperUsername (
+  db: D1Database,
+  finperUsername: string
+): Promise<number[]> {
+  const result = await db
+    .prepare('SELECT user_id FROM allowed_users WHERE finper_username = ?')
+    .bind(finperUsername)
+    .all<{ user_id: number }>()
+  return result.results.map(row => row.user_id)
 }

--- a/packages/bot/src/handlers/api.ts
+++ b/packages/bot/src/handlers/api.ts
@@ -1,20 +1,38 @@
 import type { Context } from 'hono'
-import type { Env } from '../types'
-import { getTickets, markTicketReviewed, getTicketById, deleteTicket } from '../db/tickets'
+import type { Env, Ticket } from '../types'
+import { getTickets, getTicketById, deleteTicket } from '../db/tickets'
 
 /**
- * GET /api/tickets?status=pending|reviewed|all
+ * Deletes a ticket's image from R2 (if present) and its row from D1.
+ */
+async function deleteTicketAndImage (env: Env, ticket: Ticket): Promise<boolean> {
+  if (ticket.image_url) {
+    await env.TICKET_IMAGES.delete(ticket.image_url)
+  }
+  return deleteTicket(env.DB, ticket.id)
+}
+
+/**
+ * GET /api/tickets?status=pending|reviewed|all&finper_username=
  * Returns tickets list for finper-api to consume.
  * image_url is transformed from R2 key to a full Worker URL (/images/<key>).
+ * finper_username is required: only tickets sent by Telegram users linked to
+ * that Finper username are returned. Tickets without a telegram_user_id
+ * (legacy rows) are never returned.
  */
 export async function getTicketsHandler (c: Context<{ Bindings: Env }>): Promise<Response> {
   const status = (c.req.query('status') as 'pending' | 'reviewed' | 'all') || 'pending'
+  const finperUsername = c.req.query('finper_username')
 
   if (!['pending', 'reviewed', 'all'].includes(status)) {
     return c.json({ error: 'Invalid status. Use: pending, reviewed, all' }, 400)
   }
 
-  const tickets = await getTickets(c.env.DB, status)
+  if (!finperUsername) {
+    return c.json({ error: 'Missing finper_username' }, 400)
+  }
+
+  const tickets = await getTickets(c.env.DB, status, finperUsername)
 
   // Build base URL from the incoming request (works in both dev and prod)
   const url = new URL(c.req.url)
@@ -30,7 +48,9 @@ export async function getTicketsHandler (c: Context<{ Bindings: Env }>): Promise
 
 /**
  * PATCH /api/tickets/:id
- * Marks a ticket as reviewed
+ * Marks a ticket as reviewed. The transaction has already been created in
+ * Finper at this point, so the ticket and its image are no longer needed
+ * and are deleted (same as DELETE).
  */
 export async function reviewTicketHandler (c: Context<{ Bindings: Env }>): Promise<Response> {
   const id = c.req.param('id')
@@ -48,9 +68,9 @@ export async function reviewTicketHandler (c: Context<{ Bindings: Env }>): Promi
     return c.json({ error: 'Ticket already reviewed' }, 409)
   }
 
-  const updated = await markTicketReviewed(c.env.DB, id)
+  const deleted = await deleteTicketAndImage(c.env, ticket)
 
-  if (!updated) {
+  if (!deleted) {
     return c.json({ error: 'Failed to update ticket' }, 500)
   }
 
@@ -73,12 +93,7 @@ export async function deleteTicketHandler (c: Context<{ Bindings: Env }>): Promi
     return c.json({ error: 'Ticket not found' }, 404)
   }
 
-  // Delete image from R2 if present
-  if (ticket.image_url) {
-    await c.env.TICKET_IMAGES.delete(ticket.image_url)
-  }
-
-  const deleted = await deleteTicket(c.env.DB, id)
+  const deleted = await deleteTicketAndImage(c.env, ticket)
   if (!deleted) {
     return c.json({ error: 'Failed to delete ticket' }, 500)
   }

--- a/packages/bot/src/handlers/telegram.ts
+++ b/packages/bot/src/handlers/telegram.ts
@@ -74,17 +74,18 @@ export async function telegramWebhookHandler (c: Context<{ Bindings: Env }>): Pr
       if (text.startsWith('/adduser')) {
         const parts = text.split(/\s+/)
         const targetId = parts[1] ? parseInt(parts[1], 10) : NaN
-        if (isNaN(targetId)) {
-          await sendTelegramMessage(chatId, '⚠️ Uso: /adduser <id_de_telegram>', c.env.TELEGRAM_BOT_TOKEN)
+        const finperUsername = parts[2]
+        if (isNaN(targetId) || !finperUsername) {
+          await sendTelegramMessage(chatId, '⚠️ Uso: /adduser <id_de_telegram> <usuario_finper>', c.env.TELEGRAM_BOT_TOKEN)
           return c.json({ ok: true })
         }
         if (targetId === adminUserId) {
           await sendTelegramMessage(chatId, 'ℹ️ El administrador ya tiene acceso por defecto.', c.env.TELEGRAM_BOT_TOKEN)
           return c.json({ ok: true })
         }
-        const added = await addAllowedUser(c.env.DB, targetId, adminUserId)
+        const added = await addAllowedUser(c.env.DB, targetId, adminUserId, finperUsername)
         if (added) {
-          await sendTelegramMessage(chatId, `✅ Usuario <code>${targetId}</code> añadido correctamente.`, c.env.TELEGRAM_BOT_TOKEN)
+          await sendTelegramMessage(chatId, `✅ Usuario <code>${targetId}</code> añadido correctamente y vinculado a <code>${finperUsername}</code>.`, c.env.TELEGRAM_BOT_TOKEN)
         } else {
           await sendTelegramMessage(chatId, `ℹ️ El usuario <code>${targetId}</code> ya tenía acceso.`, c.env.TELEGRAM_BOT_TOKEN)
         }
@@ -120,7 +121,8 @@ export async function telegramWebhookHandler (c: Context<{ Bindings: Env }>): Pr
           lines.push(`• <code>${adminUserId}</code> — admin (tú)`)
           for (const u of users) {
             const date = formatDate(u.added_at)
-            lines.push(`• <code>${u.user_id}</code> — añadido el ${date}`)
+            const linkInfo = u.finper_username ? `finper: ${u.finper_username}` : 'sin vincular'
+            lines.push(`• <code>${u.user_id}</code> — añadido el ${date} — ${linkInfo}`)
           }
           await sendTelegramMessage(chatId, lines.join('\n'), c.env.TELEGRAM_BOT_TOKEN)
         }
@@ -178,6 +180,7 @@ async function processTicketText (
       id: ticketId,
       telegram_message_id: messageId,
       telegram_chat_id: chatId,
+      telegram_user_id: userId,
       image_url: null,
       date: extraction.date,
       store: extraction.store,
@@ -252,6 +255,7 @@ async function processTicketPhoto (
       id: ticketId,
       telegram_message_id: messageId,
       telegram_chat_id: chatId,
+      telegram_user_id: userId,
       image_url: r2Key,
       date: extraction.date,
       store: extraction.store,

--- a/packages/bot/src/types.ts
+++ b/packages/bot/src/types.ts
@@ -2,6 +2,7 @@ export interface Ticket {
   id: string
   telegram_message_id: number
   telegram_chat_id: number
+  telegram_user_id: number | null
   image_url: string | null
   date: number | null
   store: string | null

--- a/packages/client/src/types/ticket.ts
+++ b/packages/client/src/types/ticket.ts
@@ -2,6 +2,7 @@ export interface Ticket {
   id: string
   telegram_message_id: number
   telegram_chat_id: number
+  telegram_user_id: number | null
   image_url: string | null
   date: number | null
   store: string | null


### PR DESCRIPTION
## Problema

Cualquier usuario de Telegram autorizado en la whitelist (`allowed_users`) alimentaba una **única cola global** de tickets pendientes en el bot. Al añadir un nuevo usuario de Finper, sus recibos (o los de los usuarios de Telegram existentes) no estaban aislados por cuenta/usuario — `GET /api/tickets` devolvía todo a cualquiera con acceso al panel de tickets.

## Solución

- **`allowed_users`** (D1) gana `finper_username`: cada Telegram user se vincula a un username de Finper. Varios `telegram_user_id` pueden compartir el mismo `finper_username` (n:1).
- **`tickets`** (D1) gana `telegram_user_id`, persistido en cada alta desde `telegram.ts` (antes solo se guardaba `telegram_chat_id`).
- `GET /api/tickets` ahora **exige** `finper_username` y solo devuelve tickets cuyo `telegram_user_id` está vinculado a ese username. Los tickets antiguos sin `telegram_user_id` quedan excluidos permanentemente (comportamiento esperado, decisión explícita).
- `/adduser <telegram_id> <finper_username>` en el bot ahora exige el username de Finper al dar de alta un usuario de Telegram. `/listusers` muestra el vínculo.
- Al **revisar** un ticket (`PATCH /api/tickets/:id`, tras crear el movimiento en Finper) ahora se borra la fila de D1 y la imagen de R2, igual que al eliminarlo — ya no tiene sentido conservar tickets "reviewed". Se eliminó `markTicketReviewed` (código muerto).
- `ticket.controller.ts`/`ticket.service.ts` de `finper-api` propagan el `req.user` (username autenticado vía JWT) en cada llamada al bot.

## Pendiente tras el merge (manual, fuera de este PR)

- Ejecutar en D1 remoto:
  ```sql
  ALTER TABLE allowed_users ADD COLUMN finper_username TEXT;
  ALTER TABLE tickets ADD COLUMN telegram_user_id INTEGER;
  ```
  (necesario porque `schema.sql` usa `CREATE TABLE IF NOT EXISTS`, no migra tablas existentes).
- Vincular los usuarios de Telegram actuales a sus usernames de Finper (`UPDATE allowed_users SET finper_username = ...` o vía `/adduser`).

## Testing

- `make lint-bot` / `make type-check-bot` ✅
- `tsc --noEmit` en `api` y `client` ✅
- `packages/api/test/routes/ticket.routes.test.ts` (12/12) ✅
- Suite completa vía pre-commit hook: API 613/613, client 269/269 ✅
- `packages/bot` no tiene test framework configurado (documentado en su AGENTS.md)