### PR TITLE
fix(ci): force npm-script resolution for deploy-bot target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ start-bot:
 	@pnpm --filter @soker90/finper-bot dev
 
 deploy-bot:
-	@pnpm --filter @soker90/finper-bot deploy
+	@pnpm --filter @soker90/finper-bot run deploy
 
 lint-bot:
 	@pnpm --filter @soker90/finper-bot lint


### PR DESCRIPTION
## Problema

El job `deploy-bot` fallaba en CI tras el merge de #878:

```
ERR_PNPM_INVALID_DEPLOY_TARGET  This command requires one parameter
make: *** [Makefile:95: deploy-bot] Error 1
```

## Causa

`pnpm --filter @soker90/finper-bot deploy` era interpretado por pnpm como el comando reservado `pnpm deploy <dir>` (usado para generar paquetes de despliegue aislados), en lugar de ejecutar el script `deploy` (`wrangler deploy`) definido en `packages/bot/package.json`.

## Fix

Usar `pnpm run deploy` en vez de `pnpm deploy`, forzando la resolución explícita hacia el script del `package.json` y evitando la colisión con el subcomando reservado.

## Verificación

- Verificado localmente: `pnpm --filter @soker90/finper-bot run deploy` ejecuta correctamente `wrangler deploy` (confirmado el Worker desplegado con éxito).
- Se migró manualmente el esquema de D1 remoto (`ALTER TABLE tickets ADD COLUMN telegram_user_id INTEGER;` y `ALTER TABLE allowed_users ADD COLUMN finper_username TEXT;`) tras confirmar que el Worker con el código de #878 ya estaba en producción sin esas columnas.