### PR TITLE
fix(bot): allow linking the admin's Telegram ID to a Finper username

### DIFF
--- a/packages/bot/src/db/users.ts
+++ b/packages/bot/src/db/users.ts
@@ -7,8 +7,10 @@ export interface AllowedUser {
 
 /**
  * Returns true if the given userId is allowed to use the bot.
- * The admin (checked separately via env var) is always allowed and is NOT
- * stored in this table.
+ * The admin (checked separately via env var) is always allowed regardless
+ * of whether it has a row in this table. The admin can still be added here
+ * (via /adduser) purely to link its Telegram ID to a Finper username, so its
+ * own tickets are filterable too.
  */
 export async function isUserAllowed (db: D1Database, userId: number): Promise<boolean> {
   const result = await db
@@ -63,19 +65,4 @@ export async function listAllowedUsers (db: D1Database): Promise<AllowedUser[]> 
     .prepare('SELECT user_id, added_by, added_at, finper_username FROM allowed_users ORDER BY added_at ASC')
     .all<AllowedUser>()
   return result.results
-}
-
-/**
- * Returns the Telegram user IDs linked to the given Finper username.
- * Used to filter tickets by the currently authenticated Finper user.
- */
-export async function listTelegramUserIdsByFinperUsername (
-  db: D1Database,
-  finperUsername: string
-): Promise<number[]> {
-  const result = await db
-    .prepare('SELECT user_id FROM allowed_users WHERE finper_username = ?')
-    .bind(finperUsername)
-    .all<{ user_id: number }>()
-  return result.results.map(row => row.user_id)
 }

--- a/packages/bot/src/handlers/telegram.ts
+++ b/packages/bot/src/handlers/telegram.ts
@@ -76,18 +76,14 @@ export async function telegramWebhookHandler (c: Context<{ Bindings: Env }>): Pr
         const targetId = parts[1] ? parseInt(parts[1], 10) : NaN
         const finperUsername = parts[2]
         if (isNaN(targetId) || !finperUsername) {
-          await sendTelegramMessage(chatId, '⚠️ Uso: /adduser <id_de_telegram> <usuario_finper>', c.env.TELEGRAM_BOT_TOKEN)
-          return c.json({ ok: true })
-        }
-        if (targetId === adminUserId) {
-          await sendTelegramMessage(chatId, 'ℹ️ El administrador ya tiene acceso por defecto.', c.env.TELEGRAM_BOT_TOKEN)
+          await sendTelegramMessage(chatId, '⚠️ Uso: /adduser <id_de_telegram> <usuario_finper>\n\nTambién puedes vincular tu propio ID de admin para que tus tickets se asocien a un usuario de Finper.', c.env.TELEGRAM_BOT_TOKEN)
           return c.json({ ok: true })
         }
         const added = await addAllowedUser(c.env.DB, targetId, adminUserId, finperUsername)
         if (added) {
           await sendTelegramMessage(chatId, `✅ Usuario <code>${targetId}</code> añadido correctamente y vinculado a <code>${finperUsername}</code>.`, c.env.TELEGRAM_BOT_TOKEN)
         } else {
-          await sendTelegramMessage(chatId, `ℹ️ El usuario <code>${targetId}</code> ya tenía acceso.`, c.env.TELEGRAM_BOT_TOKEN)
+          await sendTelegramMessage(chatId, `ℹ️ El usuario <code>${targetId}</code> ya estaba vinculado. Usa /removeuser y vuelve a añadirlo para cambiar el usuario de Finper.`, c.env.TELEGRAM_BOT_TOKEN)
         }
         return c.json({ ok: true })
       }
@@ -97,10 +93,6 @@ export async function telegramWebhookHandler (c: Context<{ Bindings: Env }>): Pr
         const targetId = parts[1] ? parseInt(parts[1], 10) : NaN
         if (isNaN(targetId)) {
           await sendTelegramMessage(chatId, '⚠️ Uso: /removeuser <id_de_telegram>', c.env.TELEGRAM_BOT_TOKEN)
-          return c.json({ ok: true })
-        }
-        if (targetId === adminUserId) {
-          await sendTelegramMessage(chatId, '⛔ No puedes eliminar al administrador.', c.env.TELEGRAM_BOT_TOKEN)
           return c.json({ ok: true })
         }
         const removed = await removeAllowedUser(c.env.DB, targetId)
@@ -114,18 +106,23 @@ export async function telegramWebhookHandler (c: Context<{ Bindings: Env }>): Pr
 
       if (text.startsWith('/listusers')) {
         const users = await listAllowedUsers(c.env.DB)
-        if (users.length === 0) {
-          await sendTelegramMessage(chatId, 'ℹ️ No hay usuarios adicionales con acceso.\n\nSolo tú (admin) tienes acceso actualmente.', c.env.TELEGRAM_BOT_TOKEN)
+        const adminEntry = users.find(u => u.user_id === adminUserId)
+        const otherUsers = users.filter(u => u.user_id !== adminUserId)
+
+        const lines = ['👥 <b>Usuarios con acceso:</b>', '']
+        const adminLinkInfo = adminEntry?.finper_username ? `finper: ${adminEntry.finper_username}` : 'sin vincular'
+        lines.push(`• <code>${adminUserId}</code> — admin (tú) — ${adminLinkInfo}`)
+
+        if (otherUsers.length === 0) {
+          lines.push('', 'ℹ️ No hay usuarios adicionales con acceso.')
         } else {
-          const lines = ['👥 <b>Usuarios con acceso:</b>', '']
-          lines.push(`• <code>${adminUserId}</code> — admin (tú)`)
-          for (const u of users) {
+          for (const u of otherUsers) {
             const date = formatDate(u.added_at)
             const linkInfo = u.finper_username ? `finper: ${u.finper_username}` : 'sin vincular'
             lines.push(`• <code>${u.user_id}</code> — añadido el ${date} — ${linkInfo}`)
           }
-          await sendTelegramMessage(chatId, lines.join('\n'), c.env.TELEGRAM_BOT_TOKEN)
         }
+        await sendTelegramMessage(chatId, lines.join('\n'), c.env.TELEGRAM_BOT_TOKEN)
         return c.json({ ok: true })
       }
     }


### PR DESCRIPTION
## Problema

Tras #878, la vinculación telegram_user_id → finper_username se gestiona en `allowed_users`. Pero el admin (`TELEGRAM_ADMIN_USER_ID`) nunca se guardaba en esa tabla — tiene acceso especial vía bypass en el código, independiente de la whitelist. Como consecuencia, **los tickets enviados por el propio admin nunca tendrían un `finper_username` asociado**, quedando invisibles para siempre en el filtro `GET /api/tickets?finper_username=`.

## Solución

- `/adduser <telegram_id> <finper_username>` ya no rechaza el ID del propio admin — ahora puede vincularse igual que cualquier otro usuario. El bypass de acceso del admin (vía `isAdmin`) sigue funcionando exactamente igual, independientemente de si tiene fila en `allowed_users`.
- `/removeuser` ya no bloquea especialmente el ID del admin (permite re-vincularlo a otro username borrando y re-añadiendo, ya que `addAllowedUser` solo hace `INSERT`, no upsert).
- `/listusers` ahora muestra el username de Finper vinculado al admin (o "sin vincular") junto al resto de usuarios, sin duplicar su entrada.
- Actualizado el comentario de `isUserAllowed` para reflejar que el admin puede tener fila en la tabla (solo a efectos de vínculo, no de control de acceso).
- Eliminada `listTelegramUserIdsByFinperUsername` (código muerto, nunca usada — `getTickets` ya hace su propio subquery).

## Pendiente tras el merge y deploy

Vincular el admin en D1 remoto, por ejemplo vía Telegram:
```
/adduser <admin_telegram_id> <finper_username>
```
o directamente por SQL:
```sql
UPDATE allowed_users SET finper_username = '<username>' WHERE user_id = <admin_telegram_id>;
-- o INSERT si no existe fila:
INSERT INTO allowed_users (user_id, added_by, added_at, finper_username) VALUES (<admin_telegram_id>, <admin_telegram_id>, <timestamp_ms>, '<username>');
```

## Testing

- `make lint-bot` / `make type-check-bot` ✅
- Suite completa vía pre-commit hook: API 613/613, client 269/269 ✅
- `packages/bot` no tiene test framework configurado (documentado en su AGENTS.md)