### PR TITLE
fix(docker): remove obsolete build-arg API_HOST in client image and bump to 2.3.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,6 @@ jobs:
             soker90/finper-client:${{ github.event.release.tag_name }}
           context: .
           file: ./packages/client/Dockerfile
-          build-args: API_HOST=${{ secrets.API_HOST }}
 
       - name: Build and push api
         uses: docker/build-push-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-08-19
+
+### Fixed
+
+- **docker/ci**: Remove obsolete `build-args: API_HOST` from GitHub Actions docker workflow so client Docker image uses the default `/api/` upstream proxy.
+- **client**: Add fallback `|| '/api/'` to `API_HOST` in client config to prevent empty baseURL when `VITE_API_HOST` is not set.
+- **client**: Pin pnpm version in `packages/client/Dockerfile` to `10.29.3`.
+
+---
+
 ## [2.3.0] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **docker/ci**: Remove obsolete `build-args: API_HOST` from GitHub Actions docker workflow so client Docker image uses the default `/api/` upstream proxy.
 - **client**: Add fallback `|| '/api/'` to `API_HOST` in client config to prevent empty baseURL when `VITE_API_HOST` is not set.
-- **client**: Pin pnpm version in `packages/client/Dockerfile` to `10.29.3`.
 
 ---
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-api",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Finper API that stores endpoints consumed by a Finper client",
   "main": "src/server",
   "scripts": {

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine as build
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 
 WORKDIR /home/node/app

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine as build
 
-RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
+RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 
 WORKDIR /home/node/app

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@soker90/finper-client",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/config/index.ts
+++ b/packages/client/src/config/index.ts
@@ -11,7 +11,7 @@ const config = {
 
 export default config
 export const drawerWidth = 260
-export const API_HOST = import.meta.env.VITE_API_HOST
+export const API_HOST = import.meta.env.VITE_API_HOST || '/api/'
 export const FINPER_TOKEN = 'FINPER_TOKEN'
 export const FINPER_HAS_PASSKEY = 'FINPER_HAS_PASSKEY'
 export const FINPER_LAST_USERNAME = 'FINPER_LAST_USERNAME'

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-db",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Database definitions and ORM for finper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soker90/finper-types",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Shared TypeScript types for finper",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Description

- Removes obsolete `build-args: API_HOST=${{ secrets.API_HOST }}` from the Docker CI workflow (`.github/workflows/docker.yml`) so the client Docker image uses the default `/api/` upstream proxy configuration.
- Adds fallback `|| '/api/'` in `packages/client/src/config/index.ts` as a safeguard against empty `VITE_API_HOST`.
- Bumps monorepo version to `2.3.1` and updates `CHANGELOG.md`.